### PR TITLE
Fix invalid config patches in dockyards node pool controller

### DIFF
--- a/controllers/dockyardsnodepool_controller_test.go
+++ b/controllers/dockyardsnodepool_controller_test.go
@@ -665,14 +665,14 @@ func TestDockyardsNodePoolReconciler_ReconcileTalosControlPlane(t *testing.T) {
 								Op:   "replace",
 								Path: "/cluster/apiServer/certSANs",
 								Value: apiextensionsv1.JSON{
-									Raw: []byte(strconv.Quote(owner.Status.APIEndpoint.Host)),
+									Raw: []byte("[" + strconv.Quote(owner.Status.APIEndpoint.Host) + "]"),
 								},
 							},
 							{
 								Op:   "replace",
-								Path: "/cluster/network/cni/name",
+								Path: "/cluster/network/cni",
 								Value: apiextensionsv1.JSON{
-									Raw: []byte(strconv.Quote("none")),
+									Raw: []byte("{\"name\":\"none\"}"),
 								},
 							},
 						},


### PR DESCRIPTION
Currently the config patches for cert sans and network cni are not valid config patches. Although they use valid syntax they are rejected by the talos control plane provider.