### PR TITLE
Allow skipping ingress install per cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ To keep the diagram compact, flow nodes aggregate the work that would otherwise 
 
 ### Management cluster orchestration
 `dockyards-kubevirt` runs inside `dockyards-system` alongside `dockyards-backend` and watches every Dockyards resource that defines a customer environment. The reconcilers perform distinct roles:
-- **`DockyardsClusterReconciler`** adds the shared gateway as the API and ingress anchor so the Dockyards cluster status always reports a reachable endpoint.
+- **`DockyardsClusterReconciler`** publishes the shared gateway as the API endpoint anchor and installs the default ingress controller (`ingress-nginx`) unless `Cluster.spec.noDefaultIngressProvider` is set.
 - **`DockyardsNodePoolReconciler`** bootstraps the KubeVirt/Talos templates for each node pool, wiring the appropriate machine templates, Talos configurations, and machine deployments.
 - **`DockyardsReleaseReconciler`** downloads Talos installers, stores them in CDI `DataVolume`s, and publishes the downstream `DataSource` artifacts.
 - **`DockyardsWorkloadReconciler`** owns the management-cluster `Service`, `HTTPRoute`, and `TLSRoute` objects, keeping gateway hostnames aligned with the Dockyards cluster DNS zones.
@@ -98,6 +98,12 @@ The controller stack keeps the KubeVirt and Talos artifacts aligned with the Doc
 
 ### Workload ingress and Gateway API integration
 `DockyardsWorkloadReconciler` grants the shared gateway the HTTP/TLS routes and core/v1 services that front a workload cluster service. It uses `clustercache.ClusterCache` to watch the remote services that the workload cluster creates and patches their LoadBalancer IPs so that the management cluster service status always advertises the gateway address. Once the gateway has an address the reconciler builds HTTPRoute/TLSRoute objects that advertise every customer DNS zone recorded on the owning Dockyards cluster, keeping the gateway in sync with the workload for both HTTP and TLS traffic.
+
+`DockyardsClusterReconciler` also ensures the workload cluster has a default ingress controller by creating a per-cluster Dockyards `Workload` named `<cluster>-ingress-nginx` using the `ingress-nginx` `WorkloadTemplate` in the configured public namespace.
+
+- Set `Cluster.spec.noDefaultIngressProvider: true` to skip creating/patching that default `ingress-nginx` workload.
+- This flag does not delete an existing `<cluster>-ingress-nginx` workload; remove it manually if you previously installed the default ingress controller.
+- The `--workload-ingress` flag controls whether the operator waits for a shared Gateway IPv4 address and pins the `ingress-nginx` service `loadBalancerIP` to that address; disabling it still installs `ingress-nginx` but leaves its values unmodified.
 
 ## Key components
 - **`ClusterAPIClusterReconciler`** (`controllers/clusterapicluster_controller.go`) keeps a `KubevirtCluster` in sync with every CAPI `Cluster` and populates `Cluster.Spec.InfrastructureRef` so that the provider stack owns the cluster.

--- a/controllers/condition_consts.go
+++ b/controllers/condition_consts.go
@@ -50,5 +50,6 @@ const (
 	IngressWorkloadReconciledCondition = "IngressWorkloadReconciled"
 
 	WaitingForGatewayAddressReason = "WaitingForGatewayAddress"
+	NoDefaultIngressProviderReason = "NoDefaultIngressProvider"
 	ErrorReconcilingReason         = "ErrorReconciling"
 )

--- a/controllers/dockyardscluster_controller.go
+++ b/controllers/dockyardscluster_controller.go
@@ -137,6 +137,13 @@ func (r *DockyardsClusterReconciler) reconcileAPIEndpoint(_ context.Context, doc
 }
 
 func (r *DockyardsClusterReconciler) reconcileIngressNginx(ctx context.Context, dockyardsCluster *dockyardsv1.Cluster, gateway *gatewayapiv1.Gateway) (ctrl.Result, error) {
+	if dockyardsCluster.Spec.NoDefaultIngressProvider {
+		conditions.MarkTrue(dockyardsCluster, IngressWorkloadReconciledCondition, NoDefaultIngressProviderReason, "")
+
+		return ctrl.Result{}, nil
+	}
+
+	name := dockyardsCluster.Name + "-ingress-nginx"
 	input := map[string]any{}
 
 	if r.EnableWorkloadIngress {
@@ -167,8 +174,6 @@ func (r *DockyardsClusterReconciler) reconcileIngressNginx(ctx context.Context, 
 			"loadBalancerIP": gatewayIP,
 		}
 	}
-
-	name := dockyardsCluster.Name + "-ingress-nginx"
 
 	raw, err := json.Marshal(input)
 	if err != nil {

--- a/controllers/dockyardscluster_controller_test.go
+++ b/controllers/dockyardscluster_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sudoswedenab/dockyards-kubevirt/test/mockcrds"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -329,6 +330,70 @@ func TestDockyardsClusterReconciler_ReconcileIngressNginx(t *testing.T) {
 
 		if !cmp.Equal(actual, expected, ignoreFields) {
 			t.Errorf("diff: %s", cmp.Diff(expected, actual, ignoreFields))
+		}
+	})
+
+	t.Run("test no default ingress provider skips workload", func(t *testing.T) {
+		r := DockyardsClusterReconciler{
+			Client:                mgr.GetClient(),
+			EnableWorkloadIngress: true,
+			DockyardsConfig:       dockyardsConfig,
+		}
+
+		cluster := dockyardsv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+				Namespace:    namespace.Name,
+			},
+			Spec: dockyardsv1.ClusterSpec{
+				NoDefaultIngressProvider: true,
+			},
+		}
+
+		err := c.Create(ctx, &cluster)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		gateway := gatewayapiv1.Gateway{
+			Status: gatewayapiv1.GatewayStatus{
+				Addresses: []gatewayapiv1.GatewayStatusAddress{},
+			},
+		}
+
+		_, err = r.reconcileIngressNginx(ctx, &cluster, &gateway)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := dockyardsv1.Cluster{
+			ObjectMeta: cluster.ObjectMeta,
+			Spec:       cluster.Spec,
+			Status: dockyardsv1.ClusterStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   IngressWorkloadReconciledCondition,
+						Reason: NoDefaultIngressProviderReason,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		ignoreConditionFields := cmpopts.IgnoreFields(metav1.Condition{}, "ObservedGeneration", "LastTransitionTime")
+		if !cmp.Equal(cluster, expected, ignoreConditionFields) {
+			t.Errorf("diff: %s", cmp.Diff(expected, cluster, ignoreConditionFields))
+		}
+
+		workloadKey := client.ObjectKey{
+			Name:      cluster.Name + "-ingress-nginx",
+			Namespace: namespace.Name,
+		}
+
+		var actual dockyardsv1.Workload
+		err = c.Get(ctx, workloadKey, &actual)
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("expected workload to not exist, got error: %v", err)
 		}
 	})
 


### PR DESCRIPTION
Dockyards Cluster object allows `NoDefaultIngressProvider` to be set. I
assume the intention is to skip the installation of the default ingress,
but it appears that that flag is not used in either
sudoswedenab/dockyards-backend or sudoswedenab/dockyards-kubevirt.

This commit makes sure that the flag can be used to skip installation of
the default ingress controller
