### PR TITLE
Make workload cluster authentication config configurable

### DIFF
--- a/controllers/dockyardsnodepool_controller.go
+++ b/controllers/dockyardsnodepool_controller.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/utils/ptr"
@@ -372,7 +373,10 @@ func (r *DockyardsNodePoolReconciler) reconcileMachineTemplate(ctx context.Conte
 	return ctrl.Result{}, nil
 }
 
-func (r *DockyardsNodePoolReconciler) talosConfigPatch(dockyardsCluster *dockyardsv1.Cluster) talospatchv1.Config {
+func (r *DockyardsNodePoolReconciler) talosConfigPatch(
+	dockyardsCluster *dockyardsv1.Cluster,
+	unstructuredClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI unstructured.Unstructured,
+) (talospatchv1.Config, error) {
 	// This is the patches we apply to the main talos config
 	// The file look something like this:
 	//
@@ -442,7 +446,26 @@ func (r *DockyardsNodePoolReconciler) talosConfigPatch(dockyardsCluster *dockyar
 		patch.Cluster.Discovery.Registries.Service.Endpoint = r.TalosClusterDiscoveryServiceEndpoint
 	}
 
-	return patch
+	// Authentication configuration
+	obj := unstructuredClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI.Object
+	authenticationConfig, found, err := unstructured.NestedMap(obj, "spec", "authenticationConfig")
+	if err == nil && found {
+		content, err := yaml.Marshal(authenticationConfig)
+		if err != nil {
+			return talospatchv1.Config{}, fmt.Errorf("could not marshal authentication config: %w", err)
+		}
+
+		patch.Machine.Files = append(patch.Machine.Files, talospatchv1.MachineFile{
+			Content: string(content),
+			Permissions: 0o444,
+			Path: "/manifests/authentication-config.yaml",
+			Op: "overwrite",
+		})
+
+		patch.Cluster.APIServer.ExtraArgs.Add("--authentication-config", "/var/manifests/authentication-config.yaml")
+    }
+
+	return patch, nil
 }
 
 func (r *DockyardsNodePoolReconciler) timeSyncConfigPatch(dockyardsCluster *dockyardsv1.Cluster) talospatchv1.TimeSyncConfig {
@@ -481,10 +504,32 @@ func (r *DockyardsNodePoolReconciler) timeSyncConfigPatch(dockyardsCluster *dock
 }
 
 func (r *DockyardsNodePoolReconciler) addSharedConfigPatches(
+	ctx context.Context, // FIXME: Remove context parameter when we no longer need to Get unstructured cluster
 	dockyardsCluster *dockyardsv1.Cluster,
 	strategicPatches *StrategicPatches,
 ) error {
-	err := strategicPatches.Add(ptr.To(r.talosConfigPatch(dockyardsCluster)))
+	unstructuredClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "dockyards.io/v1alpha3",
+			"kind": "Cluster",
+			"metadata": map[string]interface{}{
+				"name": dockyardsCluster.Name,
+				"namespace": dockyardsCluster.Namespace,
+			},
+		},
+	}
+
+	err := r.Get(ctx, client.ObjectKeyFromObject(&unstructuredClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI), &unstructuredClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI)
+	if err != nil {
+		return fmt.Errorf("could not get unstructured cluster object: %w", err)
+	}
+
+	patch, err := r.talosConfigPatch(dockyardsCluster, unstructuredClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI)
+	if err != nil {
+		return fmt.Errorf("could not create talos config patch: %w", err)
+	}
+	
+	err = strategicPatches.Add(&patch)
 	if err != nil {
 		return fmt.Errorf("could not add talos config patches: %w", err)
 	}
@@ -508,7 +553,7 @@ func (r *DockyardsNodePoolReconciler) reconcileTalosControlPlane(ctx context.Con
 
 	var strategicPatches StrategicPatches
 
-	err := r.addSharedConfigPatches(dockyardsCluster, &strategicPatches)
+	err := r.addSharedConfigPatches(ctx, dockyardsCluster, &strategicPatches)
 	if err != nil {
 		conditions.MarkFalse(dockyardsNodePool, TalosControlPlaneReconciledCondition, ErrorReconcilingReason, "%s", err)
 
@@ -608,7 +653,7 @@ func (r *DockyardsNodePoolReconciler) reconcileTalosConfigTemplate(ctx context.C
 
 	var strategicPatches StrategicPatches
 
-	err := r.addSharedConfigPatches(dockyardsCluster, &strategicPatches)
+	err := r.addSharedConfigPatches(ctx, dockyardsCluster, &strategicPatches)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/talospatch/v1alpha1/types.go
+++ b/internal/talospatch/v1alpha1/types.go
@@ -15,6 +15,8 @@
 package v1alpha1
 
 import (
+	"os"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -40,6 +42,7 @@ func (c *Config) IsZero() bool {
 type MachineConfig struct {
 	Kubelet KubeletConfig `yaml:"kubelet,omitempty"`
 	Env     Env           `yaml:"env,omitempty"`
+	Files   []MachineFile `yaml:"files,omitempty"`
 }
 var _ yaml.IsZeroer = &MachineConfig{}
 
@@ -48,6 +51,9 @@ func (c *MachineConfig) IsZero() bool {
 		return false
 	}
 	if !c.Env.IsZero() {
+		return false
+	}
+	if c.Files != nil {
 		return false
 	}
 	return true
@@ -80,6 +86,31 @@ func (e *Env) Set(key string, value string) *Env {
 	(*e)[key] = value
 	return e
 }
+
+type MachineFile struct {
+	Content string `yaml:"content,omitempty"`
+	Permissions os.FileMode `yaml:"permissions,omitempty"`
+	Path string `yaml:"path,omitempty"`
+	Op string `yaml:"op,omitempty"`
+}
+var _ yaml.IsZeroer = &MachineFile{}
+
+func (f *MachineFile) IsZero() bool {
+	if f.Content != "" {
+		return false
+	}
+	if f.Permissions != 0 {
+		return false
+	}
+	if f.Path != "" {
+		return false
+	}
+	if f.Op!= "" {
+		return false
+	}
+	return true
+}
+
 
 type KubeletNodeIPConfig struct {
 	ValidSubnets []string `yaml:"validSubnets,omitempty"`
@@ -168,7 +199,8 @@ func (c *ClusterConfig) IsZero() bool {
 }
 
 type APIServerConfig struct {
-	CertSANs []string `yaml:"certSANs,omitempty"`
+	CertSANs  []string `yaml:"certSANs,omitempty"`
+	ExtraArgs Args    `yaml:"extraArgs,omitempty"`
 }
 var _ yaml.IsZeroer = &APIServerConfig{}
 
@@ -178,6 +210,20 @@ func (c *APIServerConfig) IsZero() bool {
 		return false
 	}
 	return true
+}
+
+type Args map[string][]string
+var _ yaml.IsZeroer = &Args{}
+
+func (a *Args) IsZero() bool {
+	return *a == nil
+}
+
+func (a *Args) Add(key string, value string) {
+	if *a == nil {
+		*a = map[string][]string{}
+	}
+	(*a)[key] = append((*a)[key], value)
 }
 
 type ClusterDiscoveryConfig struct {


### PR DESCRIPTION
The original patch (#12), where we use the updated dockyards backend types cannot be pulled as of this moment, because talos needs to update CAPI => 12 or something along those lines.

This patch is here and dirty because we need to be able to use the new dockyards backend types, but we are unable to do so until talos has merged https://github.com/siderolabs/cluster-api-control-plane-provider-talos/pull/236 or whatever PR they decide will update cluster api.

When they have updated it, we can remove the use of unstructured kubernetes here to using the typed objects.