### PR TITLE
Change authentication config file op overwrite => create

### DIFF
--- a/controllers/dockyardsnodepool_controller.go
+++ b/controllers/dockyardsnodepool_controller.go
@@ -562,7 +562,7 @@ func (r *DockyardsNodePoolReconciler) reconcileTalosControlPlane(ctx context.Con
 			Content: string(content),
 			Permissions: 0o444,
 			Path: "/manifests/authentication-config.yaml",
-			Op: "overwrite",
+			Op: "create",
 		})
 
 		controlPlanePatch.Cluster.APIServer.ExtraArgs.Add("--authentication-config", "/var/manifests/authentication-config.yaml")


### PR DESCRIPTION
Talos does not create the file if it does not exist with file op overwrite, so use create instead.