### PR TITLE
Clusterclass topology setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ flowchart TB
 The diagram highlights how the operator turns Dockyards CRs into Cluster API/KubeVirt/Talos artifacts, mirrors load balancer state from the remote workload cluster through a cluster cache, and wires the shared Gateway to the resulting services.
 
 To keep the diagram compact, flow nodes aggregate the work that would otherwise span many edges:
-- **Kubevirt Flow** bundles the node pool provisioning path: every `DockyardsNodePoolReconciler` call produces `KubevirtCluster`, `KubevirtMachineTemplate`, `TalosControlPlane`, `TalosConfigTemplate`, and `MachineDeployment` resources (plus the CDI-backed DataVolume/DataSource assets) for each node pool.
+- **Kubevirt Flow** bundles the node pool provisioning path: by default it builds a ClusterClass topology (`KubevirtClusterTemplate`, `TalosControlPlaneTemplate`, `TalosConfigTemplate`, `KubevirtMachineTemplate`) and can fall back to low-level `TalosControlPlane` and `MachineDeployment` resources when topology mode is disabled.
 - **Workload Flow** abstracts the `DockyardsWorkloadReconciler` choreography that mirrors remote workload cluster services via `ClusterCache`, creates/patches the management-cluster `core/v1 Service`, and publishes HTTP/TLS routes to the shared gateway.
 - **Project Contour Flow** groups the gateway-side wiring (the `ClusterGatewayService` plus the Project Contour DaemonSet/Ingress components) that front the workload services for users.
 
@@ -91,8 +91,9 @@ To keep the diagram compact, flow nodes aggregate the work that would otherwise 
 
 ### KubeVirt and Talos provisioning
 The controller stack keeps the KubeVirt and Talos artifacts aligned with the Dockyards cluster and node pool specs:
-- The Cluster API cluster watcher ensures a `KubevirtCluster` infrastructure reference exists for each Dockyards cluster so the provider stack owns the control plane.
-- The node pool reconciler maintains `KubevirtMachineTemplate`, `TalosControlPlane`, `TalosConfigTemplate`, and `MachineDeployment` templates in sync with the node pool spec, release images, and shared config patches (Multus, custom node IPs, etc.).
+- Default mode (`--use-cluster-topology=true`) reconciles `ClusterClass` and `Cluster.spec.topology` from Dockyards `Cluster` and `NodePool` resources, wiring `KubevirtClusterTemplate`, `TalosControlPlaneTemplate`, `TalosConfigTemplate`, and `KubevirtMachineTemplate` references.
+- Legacy mode (`--use-cluster-topology=false`) keeps the previous low-level flow, reconciling `KubevirtCluster`, `TalosControlPlane`, `TalosConfigTemplate`, and `MachineDeployment` resources directly.
+- In both modes, node pool reconciliation keeps `KubevirtMachineTemplate` and Talos strategic patches in sync with node pool spec, release images, and shared config patches (Multus, custom node IPs, proxy/NTP/PTP, and advanced Talos patch escape hatches).
 - The release reconcilier creates/updates a CDI `DataVolume` and downstream `DataSource` that hold the latest Talos installer payload.
 - The node reconciler reads each `KubevirtMachine` to publish resource totals back into the Dockyards nodes.
 
@@ -106,8 +107,8 @@ The controller stack keeps the KubeVirt and Talos artifacts aligned with the Doc
 - The `--workload-ingress` flag controls whether the operator waits for a shared Gateway IPv4 address and pins the `ingress-nginx` service `loadBalancerIP` to that address; disabling it still installs `ingress-nginx` but leaves its values unmodified.
 
 ## Key components
-- **`ClusterAPIClusterReconciler`** (`controllers/clusterapicluster_controller.go`) keeps a `KubevirtCluster` in sync with every CAPI `Cluster` and populates `Cluster.Spec.InfrastructureRef` so that the provider stack owns the cluster.
-- **`DockyardsNodePoolReconciler`** (`controllers/dockyardsnodepool_controller.go`) ensures `KubevirtMachineTemplate`, Talos control/worker templates, and `MachineDeployment` objects match the `NodePool` spec, wiring releases, storage classes, config patches, and NodePool conditions so Talos can bring up control plane and worker replicas.
+- **`ClusterAPIClusterReconciler`** (`controllers/clusterapicluster_controller.go`) runs in topology mode by default, reconciling `KubevirtClusterTemplate`, `ClusterClass`, and `Cluster.spec.topology` from Dockyards resources; in legacy mode it keeps `KubevirtCluster` and `Cluster.Spec.InfrastructureRef` in sync.
+- **`DockyardsNodePoolReconciler`** (`controllers/dockyardsnodepool_controller.go`) always reconciles `KubevirtMachineTemplate` and Talos worker bootstrap templates, and reconciles either `TalosControlPlaneTemplate` (topology mode) or `TalosControlPlane` plus `MachineDeployment` (legacy mode), while applying shared/advanced strategic patches and NodePool conditions.
 - **`DockyardsReleaseReconciler`** (`controllers/dockyardsrelease_controller.go`) watches Talos releases, downloads the installer into a CDI `DataVolume`, creates a `DataSource`, and gives the data source creator RBAC so the Talos bootstrap can access the payload.
 - **`DockyardsWorkloadReconciler`** (`controllers/dockyardsworkload_controller.go`) mirrors the workload cluster services into the management cluster, patches their LoadBalancer statuses through `ClusterCache`, and owns the HTTPRoute/TLSRoute objects that bind them to the gateway.
 - **`DockyardsNodeReconciler`** (`controllers/dockyardsnode_controller.go`) reads `KubevirtMachine` templates to update the Dockyards node resource with current CPU/Memory/Storage totals.
@@ -127,6 +128,11 @@ go build ./...
 ```
 
 `main.go` wires all reconcilers together, loads the Dockyards config map (`dockyards-system` by default), and starts the `clustercache.ClusterCache` that lets the workload reconcilier observe remote services.
+
+Relevant runtime flags include:
+
+- `--use-cluster-topology` (default `true`) to use ClusterClass-based topology reconciliation.
+- `--workload-ingress` (default `true`) to wait for a shared Gateway IPv4 address and pin ingress service load balancer settings.
 
 ### Dockyards config map keys
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ flowchart TB
 The diagram highlights how the operator turns Dockyards CRs into Cluster API/KubeVirt/Talos artifacts, mirrors load balancer state from the remote workload cluster through a cluster cache, and wires the shared Gateway to the resulting services.
 
 To keep the diagram compact, flow nodes aggregate the work that would otherwise span many edges:
-- **Kubevirt Flow** bundles the node pool provisioning path: by default it builds a ClusterClass topology (`KubevirtClusterTemplate`, `TalosControlPlaneTemplate`, `TalosConfigTemplate`, `KubevirtMachineTemplate`) and can fall back to low-level `TalosControlPlane` and `MachineDeployment` resources when topology mode is disabled.
+- **Kubevirt Flow** bundles the node pool provisioning path: by default it builds a ClusterClass topology (`KubevirtClusterTemplate`, `TalosControlPlane`, `TalosConfigTemplate`, `KubevirtMachineTemplate`) and can fall back to low-level `TalosControlPlane` and `MachineDeployment` resources when topology mode is disabled.
 - **Workload Flow** abstracts the `DockyardsWorkloadReconciler` choreography that mirrors remote workload cluster services via `ClusterCache`, creates/patches the management-cluster `core/v1 Service`, and publishes HTTP/TLS routes to the shared gateway.
 - **Project Contour Flow** groups the gateway-side wiring (the `ClusterGatewayService` plus the Project Contour DaemonSet/Ingress components) that front the workload services for users.
 
@@ -91,7 +91,7 @@ To keep the diagram compact, flow nodes aggregate the work that would otherwise 
 
 ### KubeVirt and Talos provisioning
 The controller stack keeps the KubeVirt and Talos artifacts aligned with the Dockyards cluster and node pool specs:
-- Default mode (`--use-cluster-topology=true`) reconciles `ClusterClass` and `Cluster.spec.topology` from Dockyards `Cluster` and `NodePool` resources, wiring `KubevirtClusterTemplate`, `TalosControlPlaneTemplate`, `TalosConfigTemplate`, and `KubevirtMachineTemplate` references.
+- Default mode (`--use-cluster-topology=true`) reconciles `ClusterClass` and `Cluster.spec.topology` from Dockyards `Cluster` and `NodePool` resources, wiring `KubevirtClusterTemplate`, `TalosControlPlane`, `TalosConfigTemplate`, and `KubevirtMachineTemplate` references.
 - Legacy mode (`--use-cluster-topology=false`) keeps the previous low-level flow, reconciling `KubevirtCluster`, `TalosControlPlane`, `TalosConfigTemplate`, and `MachineDeployment` resources directly.
 - In both modes, node pool reconciliation keeps `KubevirtMachineTemplate` and Talos strategic patches in sync with node pool spec, release images, and shared config patches (Multus, custom node IPs, proxy/NTP/PTP, and advanced Talos patch escape hatches).
 - The release reconcilier creates/updates a CDI `DataVolume` and downstream `DataSource` that hold the latest Talos installer payload.
@@ -108,7 +108,7 @@ The controller stack keeps the KubeVirt and Talos artifacts aligned with the Doc
 
 ## Key components
 - **`ClusterAPIClusterReconciler`** (`controllers/clusterapicluster_controller.go`) runs in topology mode by default, reconciling `KubevirtClusterTemplate`, `ClusterClass`, and `Cluster.spec.topology` from Dockyards resources; in legacy mode it keeps `KubevirtCluster` and `Cluster.Spec.InfrastructureRef` in sync.
-- **`DockyardsNodePoolReconciler`** (`controllers/dockyardsnodepool_controller.go`) always reconciles `KubevirtMachineTemplate` and Talos worker bootstrap templates, and reconciles either `TalosControlPlaneTemplate` (topology mode) or `TalosControlPlane` plus `MachineDeployment` (legacy mode), while applying shared/advanced strategic patches and NodePool conditions.
+- **`DockyardsNodePoolReconciler`** (`controllers/dockyardsnodepool_controller.go`) always reconciles `KubevirtMachineTemplate`, `TalosControlPlane`, and Talos worker bootstrap templates; in topology mode the control plane object is used as the ClusterClass control-plane reference, while legacy mode also reconciles `MachineDeployment`, and both modes apply shared/advanced strategic patches and NodePool conditions.
 - **`DockyardsReleaseReconciler`** (`controllers/dockyardsrelease_controller.go`) watches Talos releases, downloads the installer into a CDI `DataVolume`, creates a `DataSource`, and gives the data source creator RBAC so the Talos bootstrap can access the payload.
 - **`DockyardsWorkloadReconciler`** (`controllers/dockyardsworkload_controller.go`) mirrors the workload cluster services into the management cluster, patches their LoadBalancer statuses through `ClusterCache`, and owns the HTTPRoute/TLSRoute objects that bind them to the gateway.
 - **`DockyardsNodeReconciler`** (`controllers/dockyardsnode_controller.go`) reads `KubevirtMachine` templates to update the Dockyards node resource with current CPU/Memory/Storage totals.

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ To keep the diagram compact, flow nodes aggregate the work that would otherwise 
 
 ### KubeVirt and Talos provisioning
 The controller stack keeps the KubeVirt and Talos artifacts aligned with the Dockyards cluster and node pool specs:
-- Default mode (`--use-cluster-topology=true`) reconciles `ClusterClass` and `Cluster.spec.topology` from Dockyards `Cluster` and `NodePool` resources, wiring `KubevirtClusterTemplate`, `TalosControlPlane`, `TalosConfigTemplate`, and `KubevirtMachineTemplate` references.
-- Legacy mode (`--use-cluster-topology=false`) keeps the previous low-level flow, reconciling `KubevirtCluster`, `TalosControlPlane`, `TalosConfigTemplate`, and `MachineDeployment` resources directly.
+- Topology mode (`--use-cluster-topology=true`) reconciles `ClusterClass` and `Cluster.spec.topology` from Dockyards `Cluster` and `NodePool` resources, wiring `KubevirtClusterTemplate`, `TalosControlPlane`, `TalosConfigTemplate`, and `KubevirtMachineTemplate` references.
+- Default mode (`--use-cluster-topology=false`) keeps the low-level flow, reconciling `KubevirtCluster`, `TalosControlPlane`, `TalosConfigTemplate`, and `MachineDeployment` resources directly.
 - In both modes, node pool reconciliation keeps `KubevirtMachineTemplate` and Talos strategic patches in sync with node pool spec, release images, and shared config patches (Multus, custom node IPs, proxy/NTP/PTP, and advanced Talos patch escape hatches).
 - The release reconcilier creates/updates a CDI `DataVolume` and downstream `DataSource` that hold the latest Talos installer payload.
 - The node reconciler reads each `KubevirtMachine` to publish resource totals back into the Dockyards nodes.
@@ -131,7 +131,7 @@ go build ./...
 
 Relevant runtime flags include:
 
-- `--use-cluster-topology` (default `true`) to use ClusterClass-based topology reconciliation.
+- `--use-cluster-topology` (default `false`) to opt in to ClusterClass-based topology reconciliation.
 - `--workload-ingress` (default `true`) to wait for a shared Gateway IPv4 address and pin ingress service load balancer settings.
 
 ### Dockyards config map keys

--- a/controllers/clusterapicluster_controller.go
+++ b/controllers/clusterapicluster_controller.go
@@ -17,6 +17,7 @@ package controllers
 import (
 	"context"
 
+	dockyardsv1 "github.com/sudoswedenab/dockyards-backend/api/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -26,14 +27,20 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;patch;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusterclasses,verbs=create;get;list;patch;watch
+// +kubebuilder:rbac:groups=dockyards.io,resources=clusters;nodepools,verbs=get;list;watch
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=tlsroutes,verbs=create;get;list;patch;watch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=kubevirtclusters,verbs=create;get;list;patch;watch
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=kubevirtclustertemplates,verbs=create;get;list;patch;watch
 
 type ClusterAPIClusterReconciler struct {
 	client.Client
+
+	UseClusterTopology bool
 }
 
 func (r *ClusterAPIClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, reterr error) {
@@ -56,12 +63,199 @@ func (r *ClusterAPIClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}
 	}()
 
-	result, err = r.reconcileKubevirtCluster(ctx, &cluster)
+	if r.UseClusterTopology {
+		result, err = r.reconcileClusterClassTopology(ctx, &cluster)
+	} else {
+		result, err = r.reconcileKubevirtCluster(ctx, &cluster)
+	}
 	if err != nil {
 		return result, err
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *ClusterAPIClusterReconciler) reconcileClusterClassTopology(ctx context.Context, cluster *clusterv1.Cluster) (ctrl.Result, error) {
+	logger := ctrl.LoggerFrom(ctx)
+
+	var dockyardsCluster dockyardsv1.Cluster
+	err := r.Get(ctx, client.ObjectKeyFromObject(cluster), &dockyardsCluster)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	matchingLabels := client.MatchingLabels{
+		dockyardsv1.LabelClusterName: cluster.Name,
+	}
+
+	var nodePoolList dockyardsv1.NodePoolList
+	err = r.List(ctx, &nodePoolList, matchingLabels, client.InNamespace(cluster.Namespace))
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	var controlPlaneNodePool *dockyardsv1.NodePool
+	workerNodePools := make([]dockyardsv1.NodePool, 0, len(nodePoolList.Items))
+
+	for i := range nodePoolList.Items {
+		nodePool := nodePoolList.Items[i]
+
+		if nodePool.Spec.ControlPlane {
+			if controlPlaneNodePool == nil {
+				controlPlaneNodePool = &nodePool
+			}
+
+			continue
+		}
+
+		workerNodePools = append(workerNodePools, nodePool)
+	}
+
+	if controlPlaneNodePool == nil {
+		logger.Info("ignoring cluster topology reconciliation without a control plane node pool")
+
+		return ctrl.Result{}, nil
+	}
+
+	kubevirtClusterTemplate := providerv1.KubevirtClusterTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name + "-cluster-template",
+			Namespace: cluster.Namespace,
+		},
+	}
+
+	_, err = controllerutil.CreateOrPatch(ctx, r.Client, &kubevirtClusterTemplate, func() error {
+		kubevirtClusterTemplate.Spec.Template.Spec.ControlPlaneServiceTemplate = providerv1.ControlPlaneServiceTemplate{
+			Spec: providerv1.ServiceSpecTemplate{
+				Type: corev1.ServiceTypeLoadBalancer,
+			},
+		}
+
+		return nil
+	})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	clusterClass := clusterv1.ClusterClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cluster.Name + "-class",
+			Namespace: cluster.Namespace,
+		},
+	}
+
+	_, err = controllerutil.CreateOrPatch(ctx, r.Client, &clusterClass, func() error {
+		clusterClass.Spec.Infrastructure = clusterv1.LocalObjectTemplate{
+			Ref: &corev1.ObjectReference{
+				APIVersion: providerv1.GroupVersion.String(),
+				Kind:       "KubevirtClusterTemplate",
+				Name:       kubevirtClusterTemplate.Name,
+			},
+		}
+
+		clusterClass.Spec.ControlPlane = clusterv1.ControlPlaneClass{
+			LocalObjectTemplate: clusterv1.LocalObjectTemplate{
+				Ref: &corev1.ObjectReference{
+					APIVersion: "controlplane.cluster.x-k8s.io/v1alpha3",
+					Kind:       "TalosControlPlaneTemplate",
+					Name:       controlPlaneNodePool.Name,
+				},
+			},
+			MachineInfrastructure: &clusterv1.LocalObjectTemplate{
+				Ref: &corev1.ObjectReference{
+					APIVersion: providerv1.GroupVersion.String(),
+					Kind:       "KubevirtMachineTemplate",
+					Name:       controlPlaneNodePool.Name,
+				},
+			},
+		}
+
+		clusterClass.Spec.Workers = clusterv1.WorkersClass{}
+		clusterClass.Spec.Workers.MachineDeployments = make([]clusterv1.MachineDeploymentClass, 0, len(workerNodePools))
+
+		for _, nodePool := range workerNodePools {
+			clusterClass.Spec.Workers.MachineDeployments = append(clusterClass.Spec.Workers.MachineDeployments, clusterv1.MachineDeploymentClass{
+				Class: nodePool.Name,
+				Template: clusterv1.MachineDeploymentClassTemplate{
+					Bootstrap: clusterv1.LocalObjectTemplate{
+						Ref: &corev1.ObjectReference{
+							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
+							Kind:       "TalosConfigTemplate",
+							Name:       nodePool.Name,
+						},
+					},
+					Infrastructure: clusterv1.LocalObjectTemplate{
+						Ref: &corev1.ObjectReference{
+							APIVersion: providerv1.GroupVersion.String(),
+							Kind:       "KubevirtMachineTemplate",
+							Name:       nodePool.Name,
+						},
+					},
+				},
+			})
+		}
+
+		return nil
+	})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	cluster.Spec.Topology = &clusterv1.Topology{
+		Class:   clusterClass.Name,
+		Version: dockyardsCluster.Spec.Version,
+		ControlPlane: clusterv1.ControlPlaneTopology{
+			Replicas: controlPlaneNodePool.Spec.Replicas,
+		},
+	}
+
+	if len(workerNodePools) > 0 {
+		cluster.Spec.Topology.Workers = &clusterv1.WorkersTopology{}
+		cluster.Spec.Topology.Workers.MachineDeployments = make([]clusterv1.MachineDeploymentTopology, 0, len(workerNodePools))
+
+		for _, nodePool := range workerNodePools {
+			cluster.Spec.Topology.Workers.MachineDeployments = append(cluster.Spec.Topology.Workers.MachineDeployments, clusterv1.MachineDeploymentTopology{
+				Class:    nodePool.Name,
+				Name:     nodePool.Name,
+				Replicas: nodePool.Spec.Replicas,
+			})
+		}
+	}
+
+	cluster.Spec.ControlPlaneRef = nil
+	cluster.Spec.InfrastructureRef = nil
+
+	logger.Info("reconciled cluster topology and class", "clusterClass", clusterClass.Name)
+
+	return ctrl.Result{}, nil
+}
+
+func (r *ClusterAPIClusterReconciler) dockyardsClusterToCAPICluster(_ context.Context, obj client.Object) []ctrl.Request {
+	cluster, ok := obj.(*dockyardsv1.Cluster)
+	if !ok {
+		return nil
+	}
+
+	return []ctrl.Request{{NamespacedName: client.ObjectKeyFromObject(cluster)}}
+}
+
+func (r *ClusterAPIClusterReconciler) dockyardsNodePoolToCAPICluster(_ context.Context, obj client.Object) []ctrl.Request {
+	nodePool, ok := obj.(*dockyardsv1.NodePool)
+	if !ok {
+		return nil
+	}
+
+	clusterName, hasClusterName := nodePool.Labels[dockyardsv1.LabelClusterName]
+	if !hasClusterName {
+		return nil
+	}
+
+	return []ctrl.Request{{
+		NamespacedName: client.ObjectKey{
+			Namespace: nodePool.Namespace,
+			Name:      clusterName,
+		},
+	}}
 }
 
 func (r *ClusterAPIClusterReconciler) reconcileKubevirtCluster(ctx context.Context, cluster *clusterv1.Cluster) (ctrl.Result, error) {
@@ -107,9 +301,20 @@ func (r *ClusterAPIClusterReconciler) SetupWithManager(m ctrl.Manager) error {
 	scheme := m.GetScheme()
 
 	_ = clusterv1.AddToScheme(scheme)
+	_ = dockyardsv1.AddToScheme(scheme)
 	_ = providerv1.AddToScheme(scheme)
 
-	err := ctrl.NewControllerManagedBy(m).For(&clusterv1.Cluster{}).Complete(r)
+	err := ctrl.NewControllerManagedBy(m).
+		For(&clusterv1.Cluster{}).
+		Watches(
+			&dockyardsv1.Cluster{},
+			handler.EnqueueRequestsFromMapFunc(r.dockyardsClusterToCAPICluster),
+		).
+		Watches(
+			&dockyardsv1.NodePool{},
+			handler.EnqueueRequestsFromMapFunc(r.dockyardsNodePoolToCAPICluster),
+		).
+		Complete(r)
 	if err != nil {
 		return err
 	}

--- a/controllers/clusterapicluster_controller.go
+++ b/controllers/clusterapicluster_controller.go
@@ -157,7 +157,7 @@ func (r *ClusterAPIClusterReconciler) reconcileClusterClassTopology(ctx context.
 			LocalObjectTemplate: clusterv1.LocalObjectTemplate{
 				Ref: &corev1.ObjectReference{
 					APIVersion: "controlplane.cluster.x-k8s.io/v1alpha3",
-					Kind:       "TalosControlPlaneTemplate",
+					Kind:       "TalosControlPlane",
 					Name:       controlPlaneNodePool.Name,
 				},
 			},

--- a/controllers/clusterapicluster_controller.go
+++ b/controllers/clusterapicluster_controller.go
@@ -174,6 +174,11 @@ func (r *ClusterAPIClusterReconciler) reconcileClusterClassTopology(ctx context.
 		clusterClass.Spec.Workers.MachineDeployments = make([]clusterv1.MachineDeploymentClass, 0, len(workerNodePools))
 
 		for _, nodePool := range workerNodePools {
+			talosConfigTemplateName := nodePool.Name
+			if value, ok := nodePool.Annotations[AnnotationTalosConfigTemplateName]; ok && value != "" {
+				talosConfigTemplateName = value
+			}
+
 			clusterClass.Spec.Workers.MachineDeployments = append(clusterClass.Spec.Workers.MachineDeployments, clusterv1.MachineDeploymentClass{
 				Class: nodePool.Name,
 				Template: clusterv1.MachineDeploymentClassTemplate{
@@ -181,7 +186,7 @@ func (r *ClusterAPIClusterReconciler) reconcileClusterClassTopology(ctx context.
 						Ref: &corev1.ObjectReference{
 							APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3",
 							Kind:       "TalosConfigTemplate",
-							Name:       nodePool.Name,
+							Name:       talosConfigTemplateName,
 						},
 					},
 					Infrastructure: clusterv1.LocalObjectTemplate{

--- a/controllers/clusterapicluster_controller_test.go
+++ b/controllers/clusterapicluster_controller_test.go
@@ -1,0 +1,259 @@
+// Copyright 2026 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	dockyardsv1 "github.com/sudoswedenab/dockyards-backend/api/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	providerv1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestClusterAPIClusterReconciler_reconcileClusterClassTopology(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clusterv1.AddToScheme(scheme)
+	_ = dockyardsv1.AddToScheme(scheme)
+	_ = providerv1.AddToScheme(scheme)
+
+	namespace := "test"
+	clusterName := "example"
+
+	dockyardsCluster := dockyardsv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: namespace,
+		},
+		Spec: dockyardsv1.ClusterSpec{
+			Version: "v1.35.3",
+		},
+	}
+
+	controlPlaneReplicas := int32(3)
+	workerReplicas := int32(5)
+
+	controlPlaneNodePool := dockyardsv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cp-0",
+			Namespace: namespace,
+			Labels: map[string]string{
+				dockyardsv1.LabelClusterName: clusterName,
+			},
+		},
+		Spec: dockyardsv1.NodePoolSpec{
+			ControlPlane: true,
+			Replicas:     &controlPlaneReplicas,
+		},
+	}
+
+	workerNodePool := dockyardsv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "worker-0",
+			Namespace: namespace,
+			Labels: map[string]string{
+				dockyardsv1.LabelClusterName: clusterName,
+			},
+		},
+		Spec: dockyardsv1.NodePoolSpec{
+			Replicas: &workerReplicas,
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&dockyardsCluster, &controlPlaneNodePool, &workerNodePool).
+		Build()
+
+	r := &ClusterAPIClusterReconciler{Client: c}
+
+	cluster := clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: namespace}}
+
+	_, err := r.reconcileClusterClassTopology(context.Background(), &cluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cluster.Spec.Topology == nil {
+		t.Fatal("expected cluster topology to be set")
+	}
+
+	if cluster.Spec.Topology.Class != "example-class" {
+		t.Fatalf("expected topology class %q, got %q", "example-class", cluster.Spec.Topology.Class)
+	}
+
+	if cluster.Spec.Topology.Version != "v1.35.3" {
+		t.Fatalf("expected topology version %q, got %q", "v1.35.3", cluster.Spec.Topology.Version)
+	}
+
+	if cluster.Spec.Topology.ControlPlane.Replicas == nil || *cluster.Spec.Topology.ControlPlane.Replicas != controlPlaneReplicas {
+		t.Fatalf("expected control plane replicas %d", controlPlaneReplicas)
+	}
+
+	if cluster.Spec.ControlPlaneRef != nil {
+		t.Fatalf("expected control plane ref to be nil in topology mode")
+	}
+
+	if cluster.Spec.InfrastructureRef != nil {
+		t.Fatalf("expected infrastructure ref to be nil in topology mode")
+	}
+
+	if cluster.Spec.Topology.Workers == nil || len(cluster.Spec.Topology.Workers.MachineDeployments) != 1 {
+		t.Fatalf("expected one worker topology machine deployment")
+	}
+
+	workerTopology := cluster.Spec.Topology.Workers.MachineDeployments[0]
+	if workerTopology.Class != workerNodePool.Name || workerTopology.Name != workerNodePool.Name {
+		t.Fatalf("unexpected worker topology class/name: %#v", workerTopology)
+	}
+
+	if workerTopology.Replicas == nil || *workerTopology.Replicas != workerReplicas {
+		t.Fatalf("expected worker replicas %d", workerReplicas)
+	}
+
+	var clusterClass clusterv1.ClusterClass
+	err = c.Get(context.Background(), client.ObjectKey{Name: "example-class", Namespace: namespace}, &clusterClass)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if clusterClass.Spec.ControlPlane.Ref == nil || clusterClass.Spec.ControlPlane.Ref.Kind != "TalosControlPlane" {
+		t.Fatalf("expected control plane template ref to TalosControlPlane")
+	}
+
+	if clusterClass.Spec.ControlPlane.Ref.Name != controlPlaneNodePool.Name {
+		t.Fatalf("expected control plane template ref name %q, got %q", controlPlaneNodePool.Name, clusterClass.Spec.ControlPlane.Ref.Name)
+	}
+
+	if len(clusterClass.Spec.Workers.MachineDeployments) != 1 {
+		t.Fatalf("expected one worker machine deployment class")
+	}
+
+	if clusterClass.Spec.Workers.MachineDeployments[0].Class != workerNodePool.Name {
+		t.Fatalf("expected worker class %q, got %q", workerNodePool.Name, clusterClass.Spec.Workers.MachineDeployments[0].Class)
+	}
+
+	var kubevirtClusterTemplate providerv1.KubevirtClusterTemplate
+	err = c.Get(context.Background(), client.ObjectKey{Name: "example-cluster-template", Namespace: namespace}, &kubevirtClusterTemplate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serviceType := kubevirtClusterTemplate.Spec.Template.Spec.ControlPlaneServiceTemplate.Spec.Type
+	if serviceType != corev1.ServiceTypeLoadBalancer {
+		t.Fatalf("expected service type %q, got %q", corev1.ServiceTypeLoadBalancer, serviceType)
+	}
+}
+
+func TestClusterAPIClusterReconciler_reconcileClusterClassTopologyWithoutControlPlaneNodePool(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clusterv1.AddToScheme(scheme)
+	_ = dockyardsv1.AddToScheme(scheme)
+	_ = providerv1.AddToScheme(scheme)
+
+	namespace := "test"
+	clusterName := "example"
+
+	dockyardsCluster := dockyardsv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: namespace},
+		Spec:       dockyardsv1.ClusterSpec{Version: "v1.35.3"},
+	}
+
+	workerNodePool := dockyardsv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "worker-0",
+			Namespace: namespace,
+			Labels: map[string]string{
+				dockyardsv1.LabelClusterName: clusterName,
+			},
+		},
+		Spec: dockyardsv1.NodePoolSpec{Replicas: ptr.To(int32(1))},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&dockyardsCluster, &workerNodePool).Build()
+	r := &ClusterAPIClusterReconciler{Client: c}
+	cluster := clusterv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: namespace}}
+
+	_, err := r.reconcileClusterClassTopology(context.Background(), &cluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cluster.Spec.Topology != nil {
+		t.Fatalf("expected topology to remain nil when no control plane node pool exists")
+	}
+
+	var clusterClass clusterv1.ClusterClass
+	err = c.Get(context.Background(), client.ObjectKey{Name: "example-class", Namespace: namespace}, &clusterClass)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected cluster class to not exist, got err: %v", err)
+	}
+}
+
+func TestClusterAPIClusterReconciler_ReconcileLegacyModeSetsInfrastructureRef(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = clusterv1.AddToScheme(scheme)
+	_ = providerv1.AddToScheme(scheme)
+
+	cluster := clusterv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "legacy",
+			Namespace: "test",
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&cluster).Build()
+	r := &ClusterAPIClusterReconciler{
+		Client:             c,
+		UseClusterTopology: false,
+	}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&cluster)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var actual clusterv1.Cluster
+	err = c.Get(context.Background(), client.ObjectKeyFromObject(&cluster), &actual)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if actual.Spec.InfrastructureRef == nil {
+		t.Fatalf("expected infrastructure ref to be set in legacy mode")
+	}
+
+	if actual.Spec.Topology != nil {
+		t.Fatalf("expected topology to remain nil in legacy mode")
+	}
+
+	var kubevirtCluster providerv1.KubevirtCluster
+	err = c.Get(context.Background(), client.ObjectKeyFromObject(&cluster), &kubevirtCluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if kubevirtCluster.Spec.ControlPlaneServiceTemplate.Spec.Type != corev1.ServiceTypeClusterIP {
+		t.Fatalf("expected legacy kubevirt cluster service type %q", corev1.ServiceTypeClusterIP)
+	}
+}

--- a/controllers/clusterapicluster_controller_test.go
+++ b/controllers/clusterapicluster_controller_test.go
@@ -74,6 +74,9 @@ func TestClusterAPIClusterReconciler_reconcileClusterClassTopology(t *testing.T)
 			Labels: map[string]string{
 				dockyardsv1.LabelClusterName: clusterName,
 			},
+			Annotations: map[string]string{
+				AnnotationTalosConfigTemplateName: "worker-0-abc123",
+			},
 		},
 		Spec: dockyardsv1.NodePoolSpec{
 			Replicas: &workerReplicas,
@@ -151,6 +154,11 @@ func TestClusterAPIClusterReconciler_reconcileClusterClassTopology(t *testing.T)
 
 	if clusterClass.Spec.Workers.MachineDeployments[0].Class != workerNodePool.Name {
 		t.Fatalf("expected worker class %q, got %q", workerNodePool.Name, clusterClass.Spec.Workers.MachineDeployments[0].Class)
+	}
+
+	workerBootstrapRef := clusterClass.Spec.Workers.MachineDeployments[0].Template.Bootstrap.Ref
+	if workerBootstrapRef == nil || workerBootstrapRef.Name != "worker-0-abc123" {
+		t.Fatalf("expected worker bootstrap ref name %q, got %#v", "worker-0-abc123", workerBootstrapRef)
 	}
 
 	var kubevirtClusterTemplate providerv1.KubevirtClusterTemplate

--- a/controllers/common_types.go
+++ b/controllers/common_types.go
@@ -15,5 +15,6 @@
 package controllers
 
 const (
-	LabelNetworkAsDefault = "kubevirt.dockyards.io/network-as-default"
+	LabelNetworkAsDefault             = "kubevirt.dockyards.io/network-as-default"
+	AnnotationTalosConfigTemplateName = "kubevirt.dockyards.io/talos-config-template-name"
 )

--- a/controllers/dockyardsnodepool_controller.go
+++ b/controllers/dockyardsnodepool_controller.go
@@ -16,6 +16,8 @@ package controllers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"slices"
 	"strings"
@@ -841,7 +843,7 @@ func (r *DockyardsNodePoolReconciler) reconcileTalosConfigTemplate(ctx context.C
 
 	talosConfigTemplate := bootstrapv1.TalosConfigTemplate{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      dockyardsNodePool.Name,
+			Name:      talosConfigTemplateName(dockyardsNodePool.Name, strategicPatches),
 			Namespace: dockyardsNodePool.Namespace,
 		},
 	}
@@ -857,6 +859,12 @@ func (r *DockyardsNodePoolReconciler) reconcileTalosConfigTemplate(ctx context.C
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+
+	if dockyardsNodePool.Annotations == nil {
+		dockyardsNodePool.Annotations = map[string]string{}
+	}
+
+	dockyardsNodePool.Annotations[AnnotationTalosConfigTemplateName] = talosConfigTemplate.Name
 
 	conditions.MarkTrue(dockyardsNodePool, TalosConfigTemplateReconciledCondition, ReconciledReason, "")
 
@@ -896,7 +904,7 @@ func (r *DockyardsNodePoolReconciler) reconcileMachineDeployment(ctx context.Con
 			ConfigRef: &corev1.ObjectReference{
 				APIVersion: bootstrapv1.GroupVersion.String(),
 				Kind:       "TalosConfigTemplate",
-				Name:       dockyardsNodePool.Name,
+				Name:       talosConfigTemplateNameForNodePool(dockyardsNodePool),
 			},
 		}
 
@@ -1034,6 +1042,23 @@ func (patches *StrategicPatches) AddManyUnstructured(value []any) error {
 	}
 
 	return nil
+}
+
+func talosConfigTemplateNameForNodePool(nodePool *dockyardsv1.NodePool) string {
+	if nodePool != nil {
+		if value, ok := nodePool.Annotations[AnnotationTalosConfigTemplateName]; ok && value != "" {
+			return value
+		}
+
+		return nodePool.Name
+	}
+
+	return ""
+}
+
+func talosConfigTemplateName(nodePoolName string, strategicPatches StrategicPatches) string {
+	hash := sha256.Sum256([]byte(strings.Join(strategicPatches, "\n---\n")))
+	return fmt.Sprintf("%s-%s", nodePoolName, hex.EncodeToString(hash[:6]))
 }
 
 func parseCommaSeparatedUnique(value string) []string {

--- a/controllers/dockyardsnodepool_controller.go
+++ b/controllers/dockyardsnodepool_controller.go
@@ -52,7 +52,6 @@ import (
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;patch;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments,verbs=create;get;list;patch;watch
 // +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=taloscontrolplanes,verbs=create;get;list;patch;watch
-// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=taloscontrolplanetemplates,verbs=create;get;list;patch;watch
 // +kubebuilder:rbac:groups=dockyards.io,resources=clusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=dockyards.io,resources=nodepools/status,verbs=patch
 // +kubebuilder:rbac:groups=dockyards.io,resources=nodepools,verbs=get;list;watch
@@ -117,7 +116,7 @@ func (r *DockyardsNodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	if dockyardsNodePool.Spec.ControlPlane {
 		if r.UseClusterTopology {
-			return r.reconcileTalosControlPlaneTemplate(ctx, &dockyardsNodePool, ownerCluster)
+			return r.reconcileTalosControlPlaneTopologyReference(ctx, &dockyardsNodePool, ownerCluster)
 		}
 
 		return r.reconcileTalosControlPlane(ctx, &dockyardsNodePool, ownerCluster)
@@ -142,7 +141,7 @@ func (r *DockyardsNodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	return ctrl.Result{}, nil
 }
 
-func (r *DockyardsNodePoolReconciler) reconcileTalosControlPlaneTemplate(ctx context.Context, dockyardsNodePool *dockyardsv1.NodePool, dockyardsCluster *dockyardsv1.Cluster) (ctrl.Result, error) {
+func (r *DockyardsNodePoolReconciler) reconcileTalosControlPlaneTopologyReference(ctx context.Context, dockyardsNodePool *dockyardsv1.NodePool, dockyardsCluster *dockyardsv1.Cluster) (ctrl.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
 	unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI := unstructured.Unstructured{
@@ -225,34 +224,36 @@ func (r *DockyardsNodePoolReconciler) reconcileTalosControlPlaneTemplate(ctx con
 		}
 	}
 
-	talosControlPlaneTemplate := unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "controlplane.cluster.x-k8s.io/v1alpha3",
-			"kind":       "TalosControlPlaneTemplate",
-			"metadata": map[string]any{
-				"name":      dockyardsNodePool.Name,
-				"namespace": dockyardsNodePool.Namespace,
-			},
+	talosControlPlane := controlplanev1.TalosControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dockyardsNodePool.Name,
+			Namespace: dockyardsNodePool.Namespace,
 		},
 	}
 
-	operationResult, err := controllerutil.CreateOrPatch(ctx, r.Client, &talosControlPlaneTemplate, func() error {
-		templateSpec := map[string]any{
-			"version": dockyardsCluster.Spec.Version,
-			"controlPlaneConfig": map[string]any{
-				"controlplane": bootstrapv1.TalosConfigSpec{
-					GenerateType:     "controlplane",
-					TalosVersion:     "v1.12",
-					StrategicPatches: strategicPatches,
-				},
+	operationResult, err := controllerutil.CreateOrPatch(ctx, r.Client, &talosControlPlane, func() error {
+		talosControlPlane.Spec.Version = dockyardsCluster.Spec.Version
+
+		if dockyardsNodePool.Spec.Replicas != nil {
+			talosControlPlane.Spec.Replicas = dockyardsNodePool.Spec.Replicas
+		}
+
+		talosControlPlane.Spec.InfrastructureTemplate = corev1.ObjectReference{
+			APIVersion: providerv1.GroupVersion.String(),
+			Kind:       "KubevirtMachineTemplate",
+			Name:       dockyardsNodePool.Name,
+			Namespace:  dockyardsNodePool.Namespace,
+		}
+
+		talosControlPlane.Spec.ControlPlaneConfig = controlplanev1.ControlPlaneConfig{
+			ControlPlaneConfig: bootstrapv1.TalosConfigSpec{
+				GenerateType:     "controlplane",
+				TalosVersion:     "v1.12",
+				StrategicPatches: strategicPatches,
 			},
 		}
 
-		if dockyardsNodePool.Spec.Replicas != nil {
-			templateSpec["replicas"] = *dockyardsNodePool.Spec.Replicas
-		}
-
-		return unstructured.SetNestedMap(talosControlPlaneTemplate.Object, templateSpec, "spec", "template", "spec")
+		return nil
 	})
 	if err != nil {
 		conditions.MarkFalse(dockyardsNodePool, TalosControlPlaneReconciledCondition, ErrorReconcilingReason, "%s", err)
@@ -261,7 +262,7 @@ func (r *DockyardsNodePoolReconciler) reconcileTalosControlPlaneTemplate(ctx con
 	}
 
 	if operationResult != controllerutil.OperationResultNone {
-		logger.Info("reconciled talos control plane template", "result", operationResult)
+		logger.Info("reconciled talos control plane for topology reference", "result", operationResult)
 	}
 
 	conditions.MarkTrue(dockyardsNodePool, TalosControlPlaneReconciledCondition, ReconciledReason, "")

--- a/controllers/dockyardsnodepool_controller.go
+++ b/controllers/dockyardsnodepool_controller.go
@@ -52,6 +52,7 @@ import (
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters,verbs=get;list;patch;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments,verbs=create;get;list;patch;watch
 // +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=taloscontrolplanes,verbs=create;get;list;patch;watch
+// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=taloscontrolplanetemplates,verbs=create;get;list;patch;watch
 // +kubebuilder:rbac:groups=dockyards.io,resources=clusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=dockyards.io,resources=nodepools/status,verbs=patch
 // +kubebuilder:rbac:groups=dockyards.io,resources=nodepools,verbs=get;list;watch
@@ -70,6 +71,7 @@ type DockyardsNodePoolReconciler struct {
 	EnableMultus                         bool
 	ValidNodeIPSubnets                   []string
 	UseBlockStorage                      bool
+	UseClusterTopology                   bool
 	DockyardsConfig                      *dyconfig.ConfigManager
 }
 
@@ -114,6 +116,10 @@ func (r *DockyardsNodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	if dockyardsNodePool.Spec.ControlPlane {
+		if r.UseClusterTopology {
+			return r.reconcileTalosControlPlaneTemplate(ctx, &dockyardsNodePool, ownerCluster)
+		}
+
 		return r.reconcileTalosControlPlane(ctx, &dockyardsNodePool, ownerCluster)
 	}
 
@@ -122,10 +128,143 @@ func (r *DockyardsNodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return result, err
 	}
 
+	if r.UseClusterTopology {
+		conditions.MarkTrue(&dockyardsNodePool, MachineDeploymentReconciledCondition, ReconciledReason, "")
+
+		return ctrl.Result{}, nil
+	}
+
 	result, err = r.reconcileMachineDeployment(ctx, &dockyardsNodePool, ownerCluster)
 	if err != nil {
 		return result, err
 	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *DockyardsNodePoolReconciler) reconcileTalosControlPlaneTemplate(ctx context.Context, dockyardsNodePool *dockyardsv1.NodePool, dockyardsCluster *dockyardsv1.Cluster) (ctrl.Result, error) {
+	logger := ctrl.LoggerFrom(ctx)
+
+	unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "dockyards.io/v1alpha3",
+			"kind":       "Cluster",
+			"metadata": map[string]any{
+				"name":      dockyardsCluster.Name,
+				"namespace": dockyardsCluster.Namespace,
+			},
+		},
+	}
+
+	err := r.Get(ctx, client.ObjectKeyFromObject(&unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI), &unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("could not get unstructured cluster object: %w", err)
+	}
+
+	var strategicPatches StrategicPatches
+
+	err = r.addSharedConfigPatches(dockyardsCluster, unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI, &strategicPatches)
+	if err != nil {
+		conditions.MarkFalse(dockyardsNodePool, TalosControlPlaneReconciledCondition, ErrorReconcilingReason, "%s", err)
+
+		return ctrl.Result{}, nil
+	}
+
+	controlPlanePatch := talospatchv1.Config{
+		Version: talospatchv1.ConfigVersion,
+	}
+	if dockyardsCluster.Status.APIEndpoint.Host != "" {
+		controlPlanePatch.Cluster.APIServer.CertSANs = []string{dockyardsCluster.Status.APIEndpoint.Host}
+	}
+
+	if len(r.ValidNodeIPSubnets) > 0 {
+		controlPlanePatch.Cluster.ETCD.AdvertisedSubnets = r.ValidNodeIPSubnets
+		controlPlanePatch.Cluster.ETCD.ListenSubnets = r.ValidNodeIPSubnets
+	}
+
+	if dockyardsCluster.Spec.NoDefaultNetworkPlugin {
+		controlPlanePatch.Cluster.Network.CNI.Name = ptr.To("none")
+	}
+
+	obj := unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI.Object
+	authenticationConfig, found, err := unstructured.NestedMap(obj, "spec", "authenticationConfig")
+	if err == nil && found {
+		content, err := yaml.Marshal(authenticationConfig)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("could not marshal authentication config: %w", err)
+		}
+
+		controlPlanePatch.Machine.Files = append(controlPlanePatch.Machine.Files, talospatchv1.MachineFile{
+			Content:     string(content),
+			Permissions: 0o444,
+			Path:        "/var/manifests/authentication.yaml",
+			Op:          "create",
+		})
+
+		controlPlanePatch.Cluster.APIServer.ExtraArgs.Add("authentication-config", "/var/manifests/authentication.yaml")
+		controlPlanePatch.Cluster.APIServer.ExtraVolumes = append(controlPlanePatch.Cluster.APIServer.ExtraVolumes, talospatchv1.ExtraVolume{
+			HostPath:  "/var/manifests/authentication.yaml",
+			MountPath: "/var/manifests/authentication.yaml",
+			Readonly:  true,
+		})
+	}
+
+	err = strategicPatches.Add(&controlPlanePatch)
+	if err != nil {
+		conditions.MarkFalse(dockyardsNodePool, TalosControlPlaneReconciledCondition, ErrorReconcilingReason, "%s", err)
+
+		return ctrl.Result{}, nil
+	}
+
+	value := unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI.Object
+	patches, found, err := unstructured.NestedSlice(value, "spec", "advanced", "kubevirt", "talos", "additionalControlPlaneConfigPatches")
+	if found && err == nil {
+		err = strategicPatches.AddManyUnstructured(patches)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	talosControlPlaneTemplate := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "controlplane.cluster.x-k8s.io/v1alpha3",
+			"kind":       "TalosControlPlaneTemplate",
+			"metadata": map[string]any{
+				"name":      dockyardsNodePool.Name,
+				"namespace": dockyardsNodePool.Namespace,
+			},
+		},
+	}
+
+	operationResult, err := controllerutil.CreateOrPatch(ctx, r.Client, &talosControlPlaneTemplate, func() error {
+		templateSpec := map[string]any{
+			"version": dockyardsCluster.Spec.Version,
+			"controlPlaneConfig": map[string]any{
+				"controlplane": bootstrapv1.TalosConfigSpec{
+					GenerateType:     "controlplane",
+					TalosVersion:     "v1.12",
+					StrategicPatches: strategicPatches,
+				},
+			},
+		}
+
+		if dockyardsNodePool.Spec.Replicas != nil {
+			templateSpec["replicas"] = *dockyardsNodePool.Spec.Replicas
+		}
+
+		return unstructured.SetNestedMap(talosControlPlaneTemplate.Object, templateSpec, "spec", "template", "spec")
+	})
+	if err != nil {
+		conditions.MarkFalse(dockyardsNodePool, TalosControlPlaneReconciledCondition, ErrorReconcilingReason, "%s", err)
+
+		return ctrl.Result{}, nil
+	}
+
+	if operationResult != controllerutil.OperationResultNone {
+		logger.Info("reconciled talos control plane template", "result", operationResult)
+	}
+
+	conditions.MarkTrue(dockyardsNodePool, TalosControlPlaneReconciledCondition, ReconciledReason, "")
 
 	return ctrl.Result{}, nil
 }
@@ -497,7 +636,7 @@ func (r *DockyardsNodePoolReconciler) addSharedConfigPatches(
 		return fmt.Errorf("could not add time sync config patches: %w", err)
 	}
 
-	value := unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI.Object;
+	value := unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI.Object
 	patches, found, err := unstructured.NestedSlice(value, "spec", "advanced", "kubevirt", "talos", "additionalSharedConfigPatches")
 	if found && err == nil {
 		err = strategicPatches.AddManyUnstructured(patches)
@@ -515,9 +654,9 @@ func (r *DockyardsNodePoolReconciler) reconcileTalosControlPlane(ctx context.Con
 	unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI := unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "dockyards.io/v1alpha3",
-			"kind": "Cluster",
+			"kind":       "Cluster",
 			"metadata": map[string]any{
-				"name": dockyardsCluster.Name,
+				"name":      dockyardsCluster.Name,
 				"namespace": dockyardsCluster.Namespace,
 			},
 		},
@@ -590,7 +729,7 @@ func (r *DockyardsNodePoolReconciler) reconcileTalosControlPlane(ctx context.Con
 		return ctrl.Result{}, nil
 	}
 
-	value := unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI.Object;
+	value := unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI.Object
 	patches, found, err := unstructured.NestedSlice(value, "spec", "advanced", "kubevirt", "talos", "additionalControlPlaneConfigPatches")
 	if found && err == nil {
 		err = strategicPatches.AddManyUnstructured(patches)
@@ -670,9 +809,9 @@ func (r *DockyardsNodePoolReconciler) reconcileTalosConfigTemplate(ctx context.C
 	unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI := unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "dockyards.io/v1alpha3",
-			"kind": "Cluster",
+			"kind":       "Cluster",
 			"metadata": map[string]any{
-				"name": dockyardsCluster.Name,
+				"name":      dockyardsCluster.Name,
 				"namespace": dockyardsCluster.Namespace,
 			},
 		},
@@ -690,7 +829,7 @@ func (r *DockyardsNodePoolReconciler) reconcileTalosConfigTemplate(ctx context.C
 		return ctrl.Result{}, err
 	}
 
-	value := unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI.Object;
+	value := unstructuredDockyardsClusterFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackendAPI.Object
 	patches, found, err := unstructured.NestedSlice(value, "spec", "advanced", "kubevirt", "talos", "additionalWorkerConfigPatches")
 	if found && err == nil {
 		err = strategicPatches.AddManyUnstructured(patches)

--- a/controllers/dockyardsnodepool_controller_test.go
+++ b/controllers/dockyardsnodepool_controller_test.go
@@ -1517,7 +1517,7 @@ func TestDockyardsNodePoolReconciler_ReconcileTalosConfigTemplate(t *testing.T) 
 		}
 
 		var actual bootstrapv1.TalosConfigTemplate
-		err = c.Get(ctx, client.ObjectKeyFromObject(&nodePool), &actual)
+		err = c.Get(ctx, client.ObjectKey{Namespace: nodePool.Namespace, Name: talosConfigTemplateNameForNodePool(&nodePool)}, &actual)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1579,7 +1579,7 @@ func TestDockyardsNodePoolReconciler_ReconcileTalosConfigTemplate(t *testing.T) 
 		}
 
 		var actual bootstrapv1.TalosConfigTemplate
-		err = c.Get(ctx, client.ObjectKeyFromObject(&nodePool), &actual)
+		err = c.Get(ctx, client.ObjectKey{Namespace: nodePool.Namespace, Name: talosConfigTemplateNameForNodePool(&nodePool)}, &actual)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1656,7 +1656,7 @@ func TestDockyardsNodePoolReconciler_ReconcileTalosConfigTemplate(t *testing.T) 
 		}
 
 		var actual bootstrapv1.TalosConfigTemplate
-		err = c.Get(ctx, client.ObjectKeyFromObject(&nodePool), &actual)
+		err = c.Get(ctx, client.ObjectKey{Namespace: nodePool.Namespace, Name: talosConfigTemplateNameForNodePool(&nodePool)}, &actual)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1732,7 +1732,7 @@ func TestDockyardsNodePoolReconciler_ReconcileTalosConfigTemplate(t *testing.T) 
 		}
 
 		var actual bootstrapv1.TalosConfigTemplate
-		err = c.Get(ctx, client.ObjectKeyFromObject(&nodePool), &actual)
+		err = c.Get(ctx, client.ObjectKey{Namespace: nodePool.Namespace, Name: talosConfigTemplateNameForNodePool(&nodePool)}, &actual)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1809,7 +1809,7 @@ func TestDockyardsNodePoolReconciler_ReconcileTalosConfigTemplate(t *testing.T) 
 		}
 
 		var actual bootstrapv1.TalosConfigTemplate
-		err = c.Get(ctx, client.ObjectKeyFromObject(&nodePool), &actual)
+		err = c.Get(ctx, client.ObjectKey{Namespace: nodePool.Namespace, Name: talosConfigTemplateNameForNodePool(&nodePool)}, &actual)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1885,7 +1885,7 @@ func TestDockyardsNodePoolReconciler_ReconcileTalosConfigTemplate(t *testing.T) 
 		}
 
 		var actual bootstrapv1.TalosConfigTemplate
-		err = c.Get(ctx, client.ObjectKeyFromObject(&nodePool), &actual)
+		err = c.Get(ctx, client.ObjectKey{Namespace: nodePool.Namespace, Name: talosConfigTemplateNameForNodePool(&nodePool)}, &actual)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1964,7 +1964,7 @@ func TestDockyardsNodePoolReconciler_ReconcileTalosConfigTemplate(t *testing.T) 
 		}
 
 		var actual bootstrapv1.TalosConfigTemplate
-		err = c.Get(ctx, client.ObjectKeyFromObject(&nodePool), &actual)
+		err = c.Get(ctx, client.ObjectKey{Namespace: nodePool.Namespace, Name: talosConfigTemplateNameForNodePool(&nodePool)}, &actual)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	pflag.BoolVar(&useBlockStorage, "use-block-storage", true, "use block storage")
 	pflag.StringSliceVar(&validNodeIPSubnets, "valid-node-ip-subnets", []string{}, "valid node IP subnets")
 	pflag.BoolVar(&enableWorkloadIngress, "workload-ingress", true, "enable workload ingress")
-	pflag.BoolVar(&useClusterTopology, "use-cluster-topology", true, "use CAPI ClusterClass topology instead of low-level control plane and machine deployment resources")
+	pflag.BoolVar(&useClusterTopology, "use-cluster-topology", false, "use CAPI ClusterClass topology instead of low-level control plane and machine deployment resources")
 	pflag.StringVar(&talosClusterDiscoveryServiceEndpoint, "talos-discovery-service-endpoint", "", "use talos cluster discovery service other than the default one provided by talos, set this to '0' to disable use of discovery service")
 	pflag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 	var validNodeIPSubnets []string
 	var enableWorkloadIngress bool
 	var useBlockStorage bool
+	var useClusterTopology bool
 	var talosClusterDiscoveryServiceEndpoint string
 	pflag.StringVar(&gatewayName, "gateway-name", "", "gateway name")
 	pflag.StringVar(&gatewayNamespace, "gateway-namespace", "", "gateway namespace")
@@ -62,6 +63,7 @@ func main() {
 	pflag.BoolVar(&useBlockStorage, "use-block-storage", true, "use block storage")
 	pflag.StringSliceVar(&validNodeIPSubnets, "valid-node-ip-subnets", []string{}, "valid node IP subnets")
 	pflag.BoolVar(&enableWorkloadIngress, "workload-ingress", true, "enable workload ingress")
+	pflag.BoolVar(&useClusterTopology, "use-cluster-topology", true, "use CAPI ClusterClass topology instead of low-level control plane and machine deployment resources")
 	pflag.StringVar(&talosClusterDiscoveryServiceEndpoint, "talos-discovery-service-endpoint", "", "use talos cluster discovery service other than the default one provided by talos, set this to '0' to disable use of discovery service")
 	pflag.Parse()
 
@@ -140,7 +142,8 @@ func main() {
 	}
 
 	err = (&controllers.ClusterAPIClusterReconciler{
-		Client: mgr.GetClient(),
+		Client:             mgr.GetClient(),
+		UseClusterTopology: useClusterTopology,
 	}).SetupWithManager(mgr)
 	if err != nil {
 		slogr.Error(err, "error creating clusterapi cluster reconciler")
@@ -149,13 +152,14 @@ func main() {
 	}
 
 	err = (&controllers.DockyardsNodePoolReconciler{
-		Client:                                 mgr.GetClient(),
-		TalosClusterDiscoveryServiceEndpoint:   talosClusterDiscoveryServiceEndpoint,
-		DataVolumeStorageClassName:             &dataVolumeStorageClassName,
-		EnableMultus:                           enableMultus,
-		UseBlockStorage:                        useBlockStorage,
-		ValidNodeIPSubnets:                     validNodeIPSubnets,
-		DockyardsConfig:                        dockyardsConfig,
+		Client:                               mgr.GetClient(),
+		TalosClusterDiscoveryServiceEndpoint: talosClusterDiscoveryServiceEndpoint,
+		DataVolumeStorageClassName:           &dataVolumeStorageClassName,
+		EnableMultus:                         enableMultus,
+		UseBlockStorage:                      useBlockStorage,
+		UseClusterTopology:                   useClusterTopology,
+		ValidNodeIPSubnets:                   validNodeIPSubnets,
+		DockyardsConfig:                      dockyardsConfig,
 	}).SetupWithManager(mgr)
 	if err != nil {
 		slogr.Error(err, "error creating dockyards node pool reconciler")
@@ -173,11 +177,11 @@ func main() {
 	}
 
 	err = (&controllers.DockyardsClusterReconciler{
-		Client:                 mgr.GetClient(),
-		GatewayParentReference: gatewayParentReference,
+		Client:                   mgr.GetClient(),
+		GatewayParentReference:   gatewayParentReference,
 		DockyardsSystemNamespace: dockyardsSystemNamespace,
-		DockyardsConfig:        dockyardsConfig,
-		EnableWorkloadIngress:  enableWorkloadIngress,
+		DockyardsConfig:          dockyardsConfig,
+		EnableWorkloadIngress:    enableWorkloadIngress,
 	}).SetupWithManager(mgr)
 	if err != nil {
 		slogr.Error(err, "error creating dockyards cluster reconciler")


### PR DESCRIPTION
Summary                                                                                                                  
- Add a topology-first reconciliation path for KubeVirt/Talos clusters by generating ClusterClass + Cluster.spec.topology
from Dockyards Cluster and NodePool resources, while keeping legacy classless flow behind --use-cluster-topology=false.  
- Align control plane integration with upstream Talos CRDs by using TalosControlPlane as the ClusterClass control-plane  
reference.                                                    
- Preserve and extend strategic patch behavior in topology mode (shared, control-plane, worker, and authentication config
injection), so existing escape-hatch and advanced Talos patching keeps working.                                          