### PR TITLE
feat/external node ipv4 allocation

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -36,8 +36,6 @@ rules:
   verbs:
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - bootstrap.cluster.x-k8s.io
@@ -116,19 +114,12 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
   - secrets
   verbs:
   - get
   - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -30,6 +30,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - bootstrap.cluster.x-k8s.io
   resources:
   - talosconfigs
@@ -114,12 +124,19 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - secrets
   verbs:
   - get
   - list
-  - patch
-  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,27 @@ metadata:
   name: dockyards-kubevirt
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  resources:
+  - talosconfigs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - bootstrap.cluster.x-k8s.io
   resources:
   - talosconfigtemplates
@@ -72,6 +93,15 @@ rules:
   - get
   - list
   - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  verbs:
+  - delete
+  - get
+  - list
   - watch
 - apiGroups:
   - controlplane.cluster.x-k8s.io
@@ -240,6 +270,26 @@ rules:
   - list
   - patch
   - watch
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - ipamclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - k8s.cni.cncf.io
+  resources:
+  - ipamclaims/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - k8s.cni.cncf.io
   resources:

--- a/controllers/dockyardsmachineip_controller.go
+++ b/controllers/dockyardsmachineip_controller.go
@@ -1,0 +1,886 @@
+// Copyright 2026 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/netip"
+	"slices"
+	"time"
+
+	bootstrapv1 "github.com/siderolabs/cluster-api-bootstrap-provider-talos/api/v1alpha3"
+	dockyardsv1 "github.com/sudoswedenab/dockyards-backend/api/v1alpha3"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+const (
+	ipamClaimAPIVersion = "k8s.cni.cncf.io/v1alpha1"
+	ipamClaimKind       = "IPAMClaim"
+
+	ipamStateConfigMapSuffix = "-external-node-ipam-state"
+	ipamStateConfigMapKey    = "state.json"
+
+	defaultExternalNodeInterface = "eth1"
+	reservedControlPlaneIPs      = 9
+
+	ipamClaimNameSuffix = "-external-node-ip"
+)
+
+var (
+	errNoWorkerIPsAvailable       = errors.New("no worker IPs available")
+	errNoControlPlaneIPsAvailable = errors.New("no control plane IPs available")
+)
+
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=create;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=talosconfigs,verbs=get;list;patch;update;watch
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines,verbs=delete;get;list;watch
+// +kubebuilder:rbac:groups=dockyards.io,resources=clusters,verbs=get;list;watch
+// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=ipamclaims,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=ipamclaims/status,verbs=get;patch;update
+
+type DockyardsMachineIPReconciler struct {
+	client.Client
+}
+
+func (r *DockyardsMachineIPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := ctrl.LoggerFrom(ctx)
+
+	var machine clusterv1.Machine
+	if err := r.Get(ctx, req.NamespacedName, &machine); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if machine.Spec.ClusterName == "" {
+		return ctrl.Result{}, nil
+	}
+
+	clusterKey := types.NamespacedName{Namespace: machine.Namespace, Name: machine.Spec.ClusterName}
+
+	var dockyardsCluster dockyardsv1.Cluster
+	if err := r.Get(ctx, clusterKey, &dockyardsCluster); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	config, err := r.getExternalNodeConfig(ctx, clusterKey)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if config == nil {
+		return ctrl.Result{}, nil
+	}
+
+	clusterRange, err := newIPv4Range(config.Subnet)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	machineKey := machine.Name
+	isControlPlane := machineIsControlPlane(&machine)
+	stateName := clusterKey.Name + ipamStateConfigMapSuffix
+
+	if err := r.garbageCollectLeases(ctx, clusterKey.Namespace, clusterKey.Name, stateName, clusterRange); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if !machine.DeletionTimestamp.IsZero() {
+		if err := r.releaseMachineIP(ctx, clusterKey.Namespace, stateName, machineKey, clusterRange); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		if err := r.deleteIPAMClaim(ctx, machine.Namespace, machineIPAMClaimName(machine.Name)); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{}, nil
+	}
+
+	ip, err := r.allocateMachineIP(ctx, clusterKey.Namespace, stateName, machineKey, isControlPlane, clusterRange)
+	if err != nil {
+		if errors.Is(err, errNoControlPlaneIPsAvailable) || errors.Is(err, errNoWorkerIPsAvailable) {
+			logger.Info("unable to allocate IP", "machine", machine.Name, "cluster", clusterKey.Name, "error", err)
+			return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+		}
+
+		return ctrl.Result{}, err
+	}
+
+	if err := r.ensureIPAMClaim(ctx, machine.Namespace, machineIPAMClaimName(machine.Name), clusterKey.Name, config.Interface, ip); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	talosConfigRef := machine.Spec.Bootstrap.ConfigRef
+	if talosConfigRef == nil || talosConfigRef.Kind != "TalosConfig" {
+		return ctrl.Result{}, nil
+	}
+
+	var talosConfig bootstrapv1.TalosConfig
+	talosConfigKey := types.NamespacedName{Namespace: machine.Namespace, Name: talosConfigRef.Name}
+	if err := r.Get(ctx, talosConfigKey, &talosConfig); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	desiredAddress := fmt.Sprintf("%s/%d", ip, config.Subnet.Bits())
+	updatedPatches, changed, err := upsertLinkConfigPatch(talosConfig.Spec.StrategicPatches, config.Interface, desiredAddress)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if !changed {
+		return ctrl.Result{}, nil
+	}
+
+	if talosConfig.Status.DataSecretName != nil {
+		if err := r.reconcileLatePatchMachine(ctx, &machine, clusterKey.Name, isControlPlane); err != nil {
+			return ctrl.Result{}, err
+		}
+
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	patch := client.MergeFrom(talosConfig.DeepCopy())
+	talosConfig.Spec.StrategicPatches = updatedPatches
+
+	if err := r.Patch(ctx, &talosConfig, patch); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *DockyardsMachineIPReconciler) reconcileLatePatchMachine(ctx context.Context, machine *clusterv1.Machine, clusterName string, isControlPlane bool) error {
+	deletingRoleMachine, err := r.hasDeletingMachineInRole(ctx, machine.Namespace, clusterName, isControlPlane, machine.Name)
+	if err != nil {
+		return err
+	}
+
+	if deletingRoleMachine {
+		return nil
+	}
+
+	return r.Delete(ctx, machine)
+}
+
+func (r *DockyardsMachineIPReconciler) hasDeletingMachineInRole(ctx context.Context, namespace, clusterName string, isControlPlane bool, exceptName string) (bool, error) {
+	var machineList clusterv1.MachineList
+
+	err := r.List(
+		ctx,
+		&machineList,
+		client.InNamespace(namespace),
+		client.MatchingLabels{clusterv1.ClusterNameLabel: clusterName},
+	)
+	if err != nil {
+		return false, err
+	}
+
+	for i := range machineList.Items {
+		m := &machineList.Items[i]
+		if m.Name == exceptName {
+			continue
+		}
+
+		if m.DeletionTimestamp.IsZero() {
+			continue
+		}
+
+		if machineIsControlPlane(m) == isControlPlane {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (r *DockyardsMachineIPReconciler) getExternalNodeConfig(ctx context.Context, clusterKey types.NamespacedName) (*externalNodeConfig, error) {
+	unstructuredCluster := unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": dockyardsv1.GroupVersion.String(),
+		"kind":       dockyardsv1.ClusterKind,
+		"metadata": map[string]any{
+			"name":      clusterKey.Name,
+			"namespace": clusterKey.Namespace,
+		},
+	}}
+
+	if err := r.Get(ctx, clusterKey, &unstructuredCluster); err != nil {
+		return nil, err
+	}
+
+	subnetRaw, found, err := unstructured.NestedString(unstructuredCluster.Object, "spec", "advanced", "kubevirt", "talos", "externalNodeIPv4Subnet")
+	if err != nil {
+		return nil, err
+	}
+	if !found || subnetRaw == "" {
+		return nil, nil
+	}
+
+	subnet, err := netip.ParsePrefix(subnetRaw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid externalNodeIPv4Subnet %q: %w", subnetRaw, err)
+	}
+
+	if !subnet.Addr().Is4() {
+		return nil, fmt.Errorf("externalNodeIPv4Subnet %q is not IPv4", subnetRaw)
+	}
+
+	interfaceName, found, err := unstructured.NestedString(unstructuredCluster.Object, "spec", "advanced", "kubevirt", "talos", "externalNodeInterface")
+	if err != nil {
+		return nil, err
+	}
+
+	if !found || interfaceName == "" {
+		interfaceName = defaultExternalNodeInterface
+	}
+
+	return &externalNodeConfig{Subnet: subnet.Masked(), Interface: interfaceName}, nil
+}
+
+func (r *DockyardsMachineIPReconciler) ensureIPAMClaim(ctx context.Context, namespace, claimName, networkName, ifName string, ip netip.Addr) error {
+	claim := &unstructured.Unstructured{}
+	claim.SetGroupVersionKind(schema.GroupVersionKind{Group: "k8s.cni.cncf.io", Version: "v1alpha1", Kind: ipamClaimKind})
+
+	key := types.NamespacedName{Namespace: namespace, Name: claimName}
+	err := r.Get(ctx, key, claim)
+	if apierrors.IsNotFound(err) {
+		claim.SetNamespace(namespace)
+		claim.SetName(claimName)
+		claim.Object["spec"] = map[string]any{
+			"network":   networkName,
+			"interface": ifName,
+		}
+
+		if err := r.Create(ctx, claim); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	statusIPs, found, err := unstructured.NestedStringSlice(claim.Object, "status", "ips")
+	if err != nil {
+		return err
+	}
+
+	if found && len(statusIPs) == 1 && statusIPs[0] == ip.String() {
+		return nil
+	}
+
+	statusPatch := claim.DeepCopy()
+	if err := unstructured.SetNestedStringSlice(statusPatch.Object, []string{ip.String()}, "status", "ips"); err != nil {
+		return err
+	}
+
+	return r.Status().Patch(ctx, statusPatch, client.MergeFrom(claim))
+}
+
+func (r *DockyardsMachineIPReconciler) deleteIPAMClaim(ctx context.Context, namespace, claimName string) error {
+	claim := &unstructured.Unstructured{}
+	claim.SetGroupVersionKind(schema.GroupVersionKind{Group: "k8s.cni.cncf.io", Version: "v1alpha1", Kind: ipamClaimKind})
+
+	err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: claimName}, claim)
+	if err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	return client.IgnoreNotFound(r.Delete(ctx, claim))
+}
+
+func (r *DockyardsMachineIPReconciler) allocateMachineIP(ctx context.Context, namespace, stateName, machineKey string, isControlPlane bool, subnet ipv4Range) (netip.Addr, error) {
+	var allocated netip.Addr
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		configMap, state, err := r.getOrCreateStateConfigMap(ctx, namespace, stateName)
+		if err != nil {
+			return err
+		}
+
+		if lease, ok := state.Leases[machineKey]; ok {
+			allocated = lease.IP
+			return nil
+		}
+
+		ip, err := state.allocate(isControlPlane, subnet)
+		if err != nil {
+			return err
+		}
+
+		state.Leases[machineKey] = ipLease{IP: ip, ControlPlane: isControlPlane}
+		allocated = ip
+
+		if err := persistStateConfigMap(configMap, state); err != nil {
+			return err
+		}
+
+		return r.Update(ctx, configMap)
+	})
+	if err != nil {
+		return netip.Addr{}, err
+	}
+
+	return allocated, nil
+}
+
+func (r *DockyardsMachineIPReconciler) garbageCollectLeases(ctx context.Context, namespace, clusterName, stateName string, subnet ipv4Range) error {
+	var machineList clusterv1.MachineList
+
+	err := r.List(
+		ctx,
+		&machineList,
+		client.InNamespace(namespace),
+		client.MatchingLabels{clusterv1.ClusterNameLabel: clusterName},
+	)
+	if err != nil {
+		return err
+	}
+
+	activeMachines := make(map[string]struct{}, len(machineList.Items))
+	for i := range machineList.Items {
+		activeMachines[machineList.Items[i].Name] = struct{}{}
+	}
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		configMap, state, err := r.getOrCreateStateConfigMap(ctx, namespace, stateName)
+		if err != nil {
+			return err
+		}
+
+		changed := false
+		for machineName, lease := range state.Leases {
+			if _, ok := activeMachines[machineName]; ok {
+				continue
+			}
+
+			delete(state.Leases, machineName)
+			state.release(lease, subnet)
+			changed = true
+		}
+
+		if !changed {
+			return nil
+		}
+
+		if err := persistStateConfigMap(configMap, state); err != nil {
+			return err
+		}
+
+		return r.Update(ctx, configMap)
+	})
+}
+
+func (r *DockyardsMachineIPReconciler) releaseMachineIP(ctx context.Context, namespace, stateName, machineKey string, subnet ipv4Range) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		configMap, state, err := r.getOrCreateStateConfigMap(ctx, namespace, stateName)
+		if err != nil {
+			return err
+		}
+
+		lease, ok := state.Leases[machineKey]
+		if !ok {
+			return nil
+		}
+
+		delete(state.Leases, machineKey)
+		state.release(lease, subnet)
+
+		if err := persistStateConfigMap(configMap, state); err != nil {
+			return err
+		}
+
+		return r.Update(ctx, configMap)
+	})
+}
+
+func (r *DockyardsMachineIPReconciler) getOrCreateStateConfigMap(ctx context.Context, namespace, name string) (*corev1.ConfigMap, *ipamState, error) {
+	configMap := &corev1.ConfigMap{}
+	key := types.NamespacedName{Namespace: namespace, Name: name}
+
+	err := r.Get(ctx, key, configMap)
+	if apierrors.IsNotFound(err) {
+		configMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      name,
+			},
+			Data: map[string]string{},
+		}
+
+		state := newIPAMState()
+		if err := persistStateConfigMap(configMap, state); err != nil {
+			return nil, nil, err
+		}
+
+		if err := r.Create(ctx, configMap); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				return nil, nil, err
+			}
+
+			if err := r.Get(ctx, key, configMap); err != nil {
+				return nil, nil, err
+			}
+		}
+	} else if err != nil {
+		return nil, nil, err
+	}
+
+	state, err := parseIPAMState(configMap)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return configMap, state, nil
+}
+
+func (r *DockyardsMachineIPReconciler) dockyardsClusterToMachines(ctx context.Context, obj client.Object) []ctrl.Request {
+	cluster, ok := obj.(*dockyardsv1.Cluster)
+	if !ok {
+		return nil
+	}
+
+	var machineList clusterv1.MachineList
+	err := r.List(
+		ctx,
+		&machineList,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabels{clusterv1.ClusterNameLabel: cluster.Name},
+	)
+	if err != nil {
+		return nil
+	}
+
+	requests := make([]ctrl.Request, 0, len(machineList.Items))
+	for i := range machineList.Items {
+		machine := &machineList.Items[i]
+		requests = append(requests, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(machine)})
+	}
+
+	return requests
+}
+
+func (r *DockyardsMachineIPReconciler) SetupWithManager(m ctrl.Manager) error {
+	scheme := m.GetScheme()
+
+	_ = bootstrapv1.AddToScheme(scheme)
+	_ = clusterv1.AddToScheme(scheme)
+	_ = dockyardsv1.AddToScheme(scheme)
+
+	return ctrl.NewControllerManagedBy(m).
+		For(&clusterv1.Machine{}).
+		Watches(
+			&dockyardsv1.Cluster{},
+			handler.EnqueueRequestsFromMapFunc(r.dockyardsClusterToMachines),
+		).
+		Complete(r)
+}
+
+func machineIsControlPlane(machine *clusterv1.Machine) bool {
+	_, ok := machine.Labels[clusterv1.MachineControlPlaneLabel]
+
+	return ok
+}
+
+func machineIPAMClaimName(machineName string) string {
+	return machineName + ipamClaimNameSuffix
+}
+
+type externalNodeConfig struct {
+	Subnet    netip.Prefix
+	Interface string
+}
+
+type ipLease struct {
+	IP           netip.Addr `json:"ip"`
+	ControlPlane bool       `json:"controlPlane"`
+}
+
+type ipamState struct {
+	Leases               map[string]ipLease `json:"leases"`
+	ReleasedControlPlane []netip.Addr       `json:"releasedControlPlane"`
+	ReleasedWorker       []netip.Addr       `json:"releasedWorker"`
+}
+
+func newIPAMState() *ipamState {
+	return &ipamState{Leases: map[string]ipLease{}}
+}
+
+func parseIPAMState(configMap *corev1.ConfigMap) (*ipamState, error) {
+	if configMap.Data == nil {
+		return newIPAMState(), nil
+	}
+
+	raw, ok := configMap.Data[ipamStateConfigMapKey]
+	if !ok || raw == "" {
+		return newIPAMState(), nil
+	}
+
+	var state ipamState
+	if err := json.Unmarshal([]byte(raw), &state); err != nil {
+		return nil, err
+	}
+
+	if state.Leases == nil {
+		state.Leases = map[string]ipLease{}
+	}
+
+	return &state, nil
+}
+
+func persistStateConfigMap(configMap *corev1.ConfigMap, state *ipamState) error {
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+
+	if configMap.Data == nil {
+		configMap.Data = map[string]string{}
+	}
+
+	configMap.Data[ipamStateConfigMapKey] = string(raw)
+
+	return nil
+}
+
+func (s *ipamState) allocate(controlPlane bool, subnet ipv4Range) (netip.Addr, error) {
+	inUse := make(map[uint32]struct{}, len(s.Leases))
+	for _, lease := range s.Leases {
+		inUse[ipv4ToUint32(lease.IP)] = struct{}{}
+	}
+
+	if controlPlane {
+		addr, queue, ok := popReusableIP(s.ReleasedControlPlane, inUse, subnet.controlPlaneStart, subnet.controlPlaneEnd)
+		s.ReleasedControlPlane = queue
+		if ok {
+			return addr, nil
+		}
+
+		for v := subnet.controlPlaneStart; v <= subnet.controlPlaneEnd; v++ {
+			if _, exists := inUse[v]; exists {
+				continue
+			}
+
+			return uint32ToIPv4(v), nil
+		}
+
+		return netip.Addr{}, errNoControlPlaneIPsAvailable
+	}
+
+	addr, queue, ok := popReusableIP(s.ReleasedWorker, inUse, subnet.workerStart, subnet.workerEnd)
+	s.ReleasedWorker = queue
+	if ok {
+		return addr, nil
+	}
+
+	for v := subnet.workerStart; v <= subnet.workerEnd; v++ {
+		if _, exists := inUse[v]; exists {
+			continue
+		}
+
+		return uint32ToIPv4(v), nil
+	}
+
+	return netip.Addr{}, errNoWorkerIPsAvailable
+}
+
+func (s *ipamState) release(lease ipLease, subnet ipv4Range) {
+	value := ipv4ToUint32(lease.IP)
+
+	if lease.ControlPlane {
+		if value < subnet.controlPlaneStart || value > subnet.controlPlaneEnd {
+			return
+		}
+
+		if slices.Contains(s.ReleasedControlPlane, lease.IP) {
+			return
+		}
+
+		s.ReleasedControlPlane = append(s.ReleasedControlPlane, lease.IP)
+
+		return
+	}
+
+	if value < subnet.workerStart || value > subnet.workerEnd {
+		return
+	}
+
+	if slices.Contains(s.ReleasedWorker, lease.IP) {
+		return
+	}
+
+	s.ReleasedWorker = append(s.ReleasedWorker, lease.IP)
+}
+
+func popReusableIP(queue []netip.Addr, inUse map[uint32]struct{}, start, end uint32) (netip.Addr, []netip.Addr, bool) {
+	for i, addr := range queue {
+		value := ipv4ToUint32(addr)
+		if value < start || value > end {
+			continue
+		}
+
+		if _, exists := inUse[value]; exists {
+			continue
+		}
+
+		remaining := make([]netip.Addr, 0, len(queue)-1)
+		remaining = append(remaining, queue[:i]...)
+		remaining = append(remaining, queue[i+1:]...)
+
+		return addr, remaining, true
+	}
+
+	return netip.Addr{}, queue, false
+}
+
+type ipv4Range struct {
+	network           uint32
+	broadcast         uint32
+	controlPlaneStart uint32
+	controlPlaneEnd   uint32
+	workerStart       uint32
+	workerEnd         uint32
+}
+
+func newIPv4Range(prefix netip.Prefix) (ipv4Range, error) {
+	masked := prefix.Masked()
+	if !masked.Addr().Is4() {
+		return ipv4Range{}, fmt.Errorf("subnet %q is not IPv4", prefix)
+	}
+
+	bits := masked.Bits()
+	if bits > 32 {
+		return ipv4Range{}, fmt.Errorf("invalid subnet mask bits: %d", bits)
+	}
+
+	network := ipv4ToUint32(masked.Addr())
+	hostBits := 32 - bits
+	if hostBits == 0 {
+		return ipv4Range{}, fmt.Errorf("subnet %q does not contain host addresses", prefix)
+	}
+
+	broadcast := network + (1 << hostBits) - 1
+
+	firstUsable := network + 1
+	controlPlaneStart := firstUsable + 1
+	controlPlaneEnd := controlPlaneStart + reservedControlPlaneIPs - 1
+	workerStart := controlPlaneEnd + 1
+	workerEnd := broadcast - 1
+
+	if workerStart > workerEnd {
+		return ipv4Range{}, fmt.Errorf("subnet %q too small for reserved gateway and control-plane addresses", prefix)
+	}
+
+	return ipv4Range{
+		network:           network,
+		broadcast:         broadcast,
+		controlPlaneStart: controlPlaneStart,
+		controlPlaneEnd:   controlPlaneEnd,
+		workerStart:       workerStart,
+		workerEnd:         workerEnd,
+	}, nil
+}
+
+func ipv4ToUint32(addr netip.Addr) uint32 {
+	bytes := addr.As4()
+
+	return uint32(bytes[0])<<24 | uint32(bytes[1])<<16 | uint32(bytes[2])<<8 | uint32(bytes[3])
+}
+
+func uint32ToIPv4(value uint32) netip.Addr {
+	bytes := [4]byte{
+		byte(value >> 24),
+		byte(value >> 16),
+		byte(value >> 8),
+		byte(value),
+	}
+
+	return netip.AddrFrom4(bytes)
+}
+
+func upsertLinkConfigPatch(patches []string, interfaceName, addressWithPrefix string) ([]string, bool, error) {
+	updated := slices.Clone(patches)
+	for i := range updated {
+		document := map[string]any{}
+		if err := yaml.Unmarshal([]byte(updated[i]), &document); err != nil {
+			continue
+		}
+
+		kind, _, err := unstructured.NestedString(document, "kind")
+		if err != nil || kind != "LinkConfig" {
+			continue
+		}
+
+		name, _, err := unstructured.NestedString(document, "name")
+		if err != nil || name != interfaceName {
+			continue
+		}
+
+		updatedDoc, changed, err := setLinkConfigAddress(document, interfaceName, addressWithPrefix)
+		if err != nil {
+			return nil, false, err
+		}
+
+		if !changed {
+			return patches, false, nil
+		}
+
+		raw, err := yaml.Marshal(updatedDoc)
+		if err != nil {
+			return nil, false, err
+		}
+
+		updated[i] = string(raw)
+
+		return updated, true, nil
+	}
+
+	newDoc := map[string]any{}
+	updatedDoc, _, err := setLinkConfigAddress(newDoc, interfaceName, addressWithPrefix)
+	if err != nil {
+		return nil, false, err
+	}
+
+	raw, err := yaml.Marshal(updatedDoc)
+	if err != nil {
+		return nil, false, err
+	}
+
+	updated = append(updated, string(raw))
+
+	return updated, true, nil
+}
+
+func setLinkConfigAddress(doc map[string]any, interfaceName, addressWithPrefix string) (map[string]any, bool, error) {
+	desiredPrefix, err := netip.ParsePrefix(addressWithPrefix)
+	if err != nil {
+		return nil, false, err
+	}
+
+	addresses, found, err := unstructured.NestedSlice(doc, "addresses")
+	if err != nil {
+		return nil, false, err
+	}
+	if !found {
+		addresses = nil
+	}
+
+	hadUp := false
+	up := true
+	if value, upFound, err := unstructured.NestedBool(doc, "up"); err == nil && upFound {
+		hadUp = true
+		up = value
+	} else if err != nil {
+		return nil, false, err
+	}
+
+	changed := false
+	managedSubnet := desiredPrefix.Masked()
+
+	nextAddresses := make([]any, 0, len(addresses)+1)
+	foundDesired := false
+
+	for _, entry := range addresses {
+		addrMap, ok := entry.(map[string]any)
+		if !ok {
+			nextAddresses = append(nextAddresses, entry)
+			continue
+		}
+
+		valueRaw, ok := addrMap["address"]
+		if !ok {
+			nextAddresses = append(nextAddresses, entry)
+			continue
+		}
+
+		value, ok := valueRaw.(string)
+		if !ok {
+			nextAddresses = append(nextAddresses, entry)
+			continue
+		}
+
+		existingPrefix, err := netip.ParsePrefix(value)
+		if err != nil {
+			nextAddresses = append(nextAddresses, entry)
+			continue
+		}
+
+		if existingPrefix == desiredPrefix {
+			foundDesired = true
+			nextAddresses = append(nextAddresses, entry)
+			continue
+		}
+
+		if existingPrefix.Bits() == desiredPrefix.Bits() && managedSubnet.Contains(existingPrefix.Addr()) {
+			changed = true
+			continue
+		}
+
+		nextAddresses = append(nextAddresses, entry)
+	}
+
+	if !foundDesired {
+		nextAddresses = append(nextAddresses, map[string]any{"address": addressWithPrefix})
+		changed = true
+	}
+
+	if !hadUp {
+		up = true
+		changed = true
+	}
+
+	if apiVersion, found, _ := unstructured.NestedString(doc, "apiVersion"); !found || apiVersion != "v1alpha1" {
+		changed = true
+	}
+
+	if kind, found, _ := unstructured.NestedString(doc, "kind"); !found || kind != "LinkConfig" {
+		changed = true
+	}
+
+	if name, found, _ := unstructured.NestedString(doc, "name"); !found || name != interfaceName {
+		changed = true
+	}
+
+	if err := unstructured.SetNestedField(doc, "v1alpha1", "apiVersion"); err != nil {
+		return nil, false, err
+	}
+
+	if err := unstructured.SetNestedField(doc, "LinkConfig", "kind"); err != nil {
+		return nil, false, err
+	}
+
+	if err := unstructured.SetNestedField(doc, interfaceName, "name"); err != nil {
+		return nil, false, err
+	}
+
+	if err := unstructured.SetNestedField(doc, up, "up"); err != nil {
+		return nil, false, err
+	}
+
+	if err := unstructured.SetNestedSlice(doc, nextAddresses, "addresses"); err != nil {
+		return nil, false, err
+	}
+
+	return doc, changed, nil
+}

--- a/controllers/dockyardsmachineip_controller.go
+++ b/controllers/dockyardsmachineip_controller.go
@@ -15,10 +15,12 @@
 package controllers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/netip"
 	"slices"
 	"time"
@@ -59,7 +61,8 @@ var (
 )
 
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=create;get;list;patch;update;watch
-// +kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=talosconfigs,verbs=get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;patch;update;watch
+// +kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=talosconfigs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines,verbs=delete;get;list;watch
 // +kubebuilder:rbac:groups=dockyards.io,resources=clusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=ipamclaims,verbs=create;delete;get;list;patch;update;watch
@@ -151,8 +154,23 @@ func (r *DockyardsMachineIPReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	if talosConfig.Status.DataSecretName == nil {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	bootstrapDataSecret := &corev1.Secret{}
+	bootstrapDataSecretKey := types.NamespacedName{Namespace: machine.Namespace, Name: *talosConfig.Status.DataSecretName}
+	if err := r.Get(ctx, bootstrapDataSecretKey, bootstrapDataSecret); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	bootstrapData, ok := bootstrapDataSecret.Data["value"]
+	if !ok {
+		return ctrl.Result{}, nil
+	}
+
 	desiredAddress := fmt.Sprintf("%s/%d", ip, config.Subnet.Bits())
-	updatedPatches, changed, err := upsertLinkConfigPatch(talosConfig.Spec.StrategicPatches, config.Interface, desiredAddress)
+	updatedBootstrapData, changed, err := upsertLinkConfigInBootstrapData(bootstrapData, config.Interface, desiredAddress)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -161,19 +179,19 @@ func (r *DockyardsMachineIPReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	if talosConfig.Status.DataSecretName != nil {
+	secretPatch := client.MergeFrom(bootstrapDataSecret.DeepCopy())
+	bootstrapDataSecret.Data["value"] = updatedBootstrapData
+
+	if err := r.Patch(ctx, bootstrapDataSecret, secretPatch); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if machine.Status.NodeRef != nil {
 		if err := r.reconcileLatePatchMachine(ctx, &machine, clusterKey.Name, isControlPlane); err != nil {
 			return ctrl.Result{}, err
 		}
 
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
-	}
-
-	patch := client.MergeFrom(talosConfig.DeepCopy())
-	talosConfig.Spec.StrategicPatches = updatedPatches
-
-	if err := r.Patch(ctx, &talosConfig, patch); err != nil {
-		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
@@ -823,6 +841,86 @@ func upsertLinkConfigPatch(patches []string, interfaceName, addressWithPrefix st
 	updated = append(updated, string(raw))
 
 	return updated, true, nil
+}
+
+func upsertLinkConfigInBootstrapData(data []byte, interfaceName, addressWithPrefix string) ([]byte, bool, error) {
+	documents, err := decodeYAMLDocuments(data)
+	if err != nil {
+		return nil, false, err
+	}
+
+	stringDocs := make([]string, 0, len(documents))
+	for _, doc := range documents {
+		raw, err := yaml.Marshal(doc)
+		if err != nil {
+			return nil, false, err
+		}
+
+		stringDocs = append(stringDocs, string(raw))
+	}
+
+	updatedDocs, changed, err := upsertLinkConfigPatch(stringDocs, interfaceName, addressWithPrefix)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if !changed {
+		return data, false, nil
+	}
+
+	updatedData, err := encodeYAMLDocuments(updatedDocs)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return updatedData, true, nil
+}
+
+func decodeYAMLDocuments(data []byte) ([]map[string]any, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	result := []map[string]any{}
+
+	for {
+		document := map[string]any{}
+		err := decoder.Decode(&document)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+		if len(document) == 0 {
+			continue
+		}
+
+		result = append(result, document)
+	}
+
+	return result, nil
+}
+
+func encodeYAMLDocuments(documents []string) ([]byte, error) {
+	buffer := bytes.NewBuffer(nil)
+	encoder := yaml.NewEncoder(buffer)
+
+	for _, document := range documents {
+		decoded := map[string]any{}
+		if err := yaml.Unmarshal([]byte(document), &decoded); err != nil {
+			return nil, err
+		}
+
+		if err := encoder.Encode(decoded); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := encoder.Close(); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
 }
 
 func setLinkConfigAddress(doc map[string]any, interfaceName, addressWithPrefix string) (map[string]any, bool, error) {

--- a/controllers/dockyardsmachineip_controller.go
+++ b/controllers/dockyardsmachineip_controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	bootstrapv1 "github.com/siderolabs/cluster-api-bootstrap-provider-talos/api/v1alpha3"
+	controlplanev1 "github.com/siderolabs/cluster-api-control-plane-provider-talos/api/v1alpha3"
 	dockyardsv1 "github.com/sudoswedenab/dockyards-backend/api/v1alpha3"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
@@ -47,7 +48,7 @@ const (
 	ipamStateConfigMapKey    = "state.json"
 
 	defaultExternalNodeInterface = "eth1"
-	reservedControlPlaneIPs      = 9
+	defaultControlPlaneReplicas  = 1
 
 	ipamClaimNameSuffix = "-external-node-ip"
 )
@@ -95,7 +96,12 @@ func (r *DockyardsMachineIPReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	clusterRange, err := newIPv4Range(config.Subnet)
+	controlPlaneReplicas, err := r.desiredControlPlaneReplicas(ctx, clusterKey)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	clusterRange, err := newIPv4Range(config.Subnet, controlPlaneReplicas+1)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -258,6 +264,48 @@ func (r *DockyardsMachineIPReconciler) getExternalNodeConfig(ctx context.Context
 	}
 
 	return &externalNodeConfig{Subnet: subnet.Masked(), Interface: interfaceName}, nil
+}
+
+func (r *DockyardsMachineIPReconciler) desiredControlPlaneReplicas(ctx context.Context, clusterKey types.NamespacedName) (int, error) {
+	cluster := &clusterv1.Cluster{}
+	if err := r.Get(ctx, clusterKey, cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			return defaultControlPlaneReplicas, nil
+		}
+
+		return 0, err
+	}
+
+	if cluster.Spec.ControlPlaneRef == nil {
+		return defaultControlPlaneReplicas, nil
+	}
+
+	if cluster.Spec.ControlPlaneRef.Kind != "TalosControlPlane" {
+		return defaultControlPlaneReplicas, nil
+	}
+
+	controlPlaneNamespace := cluster.Namespace
+	if cluster.Spec.ControlPlaneRef.Namespace != "" {
+		controlPlaneNamespace = cluster.Spec.ControlPlaneRef.Namespace
+	}
+
+	controlPlane := &controlplanev1.TalosControlPlane{}
+	controlPlaneKey := types.NamespacedName{Name: cluster.Spec.ControlPlaneRef.Name, Namespace: controlPlaneNamespace}
+
+	if err := r.Get(ctx, controlPlaneKey, controlPlane); err != nil {
+		if apierrors.IsNotFound(err) {
+			return defaultControlPlaneReplicas, nil
+		}
+
+		return 0, err
+	}
+
+	replicas := int(controlPlane.Spec.GetReplicas())
+	if replicas < 1 {
+		return defaultControlPlaneReplicas, nil
+	}
+
+	return replicas, nil
 }
 
 func (r *DockyardsMachineIPReconciler) ensureIPAMClaim(ctx context.Context, namespace, claimName, networkName, ifName string, ip netip.Addr) error {
@@ -486,6 +534,7 @@ func (r *DockyardsMachineIPReconciler) SetupWithManager(m ctrl.Manager) error {
 
 	_ = bootstrapv1.AddToScheme(scheme)
 	_ = clusterv1.AddToScheme(scheme)
+	_ = controlplanev1.AddToScheme(scheme)
 	_ = dockyardsv1.AddToScheme(scheme)
 
 	return ctrl.NewControllerManagedBy(m).
@@ -663,7 +712,11 @@ type ipv4Range struct {
 	workerEnd         uint32
 }
 
-func newIPv4Range(prefix netip.Prefix) (ipv4Range, error) {
+func newIPv4Range(prefix netip.Prefix, controlPlaneReserved int) (ipv4Range, error) {
+	if controlPlaneReserved < 1 {
+		controlPlaneReserved = 1
+	}
+
 	masked := prefix.Masked()
 	if !masked.Addr().Is4() {
 		return ipv4Range{}, fmt.Errorf("subnet %q is not IPv4", prefix)
@@ -684,7 +737,7 @@ func newIPv4Range(prefix netip.Prefix) (ipv4Range, error) {
 
 	firstUsable := network + 1
 	controlPlaneStart := firstUsable + 1
-	controlPlaneEnd := controlPlaneStart + reservedControlPlaneIPs - 1
+	controlPlaneEnd := controlPlaneStart + uint32(controlPlaneReserved) - 1
 	workerStart := controlPlaneEnd + 1
 	workerEnd := broadcast - 1
 

--- a/controllers/dockyardsmachineip_controller_test.go
+++ b/controllers/dockyardsmachineip_controller_test.go
@@ -292,3 +292,58 @@ addresses:
 		t.Fatalf("expected explicit up=false to be preserved")
 	}
 }
+
+func TestUpsertLinkConfigInBootstrapData(t *testing.T) {
+	t.Parallel()
+
+	bootstrapData := []byte(`version: v1alpha1
+machine:
+  kubelet:
+    nodeIP:
+      validSubnets:
+        - 10.71.22.160/27
+---
+apiVersion: v1alpha1
+kind: LinkConfig
+name: eth1
+routes:
+  - destination: 100.110.0.1/32
+    gateway: 10.71.22.161
+addresses:
+  - address: 10.71.22.172/27
+`)
+
+	updated, changed, err := upsertLinkConfigInBootstrapData(bootstrapData, "eth1", "10.71.22.173/27")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !changed {
+		t.Fatalf("expected bootstrap data to change")
+	}
+
+	documents, err := decodeYAMLDocuments(updated)
+	if err != nil {
+		t.Fatalf("failed to decode updated data: %v", err)
+	}
+
+	if len(documents) != 2 {
+		t.Fatalf("expected 2 YAML documents, got %d", len(documents))
+	}
+
+	linkConfig := documents[1]
+	routes, found, err := unstructured.NestedSlice(linkConfig, "routes")
+	if err != nil || !found || len(routes) != 1 {
+		t.Fatalf("expected routes to be preserved")
+	}
+
+	addresses, found, err := unstructured.NestedSlice(linkConfig, "addresses")
+	if err != nil || !found || len(addresses) != 1 {
+		t.Fatalf("expected one managed address")
+	}
+
+	entry := addresses[0].(map[string]any)
+	if entry["address"] != "10.71.22.173/27" {
+		t.Fatalf("unexpected managed address: %v", entry["address"])
+	}
+}

--- a/controllers/dockyardsmachineip_controller_test.go
+++ b/controllers/dockyardsmachineip_controller_test.go
@@ -27,7 +27,7 @@ func TestNewIPv4Range(t *testing.T) {
 	t.Parallel()
 
 	prefix := netip.MustParsePrefix("10.71.22.160/27")
-	rangeConfig, err := newIPv4Range(prefix)
+	rangeConfig, err := newIPv4Range(prefix, 4)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -36,11 +36,11 @@ func TestNewIPv4Range(t *testing.T) {
 		t.Fatalf("unexpected controlPlaneStart: got %q, want %q", got, want)
 	}
 
-	if got, want := uint32ToIPv4(rangeConfig.controlPlaneEnd).String(), "10.71.22.170"; got != want {
+	if got, want := uint32ToIPv4(rangeConfig.controlPlaneEnd).String(), "10.71.22.165"; got != want {
 		t.Fatalf("unexpected controlPlaneEnd: got %q, want %q", got, want)
 	}
 
-	if got, want := uint32ToIPv4(rangeConfig.workerStart).String(), "10.71.22.171"; got != want {
+	if got, want := uint32ToIPv4(rangeConfig.workerStart).String(), "10.71.22.166"; got != want {
 		t.Fatalf("unexpected workerStart: got %q, want %q", got, want)
 	}
 
@@ -52,7 +52,7 @@ func TestNewIPv4Range(t *testing.T) {
 func TestAllocateReuseAndRoleSeparation(t *testing.T) {
 	t.Parallel()
 
-	rangeConfig, err := newIPv4Range(netip.MustParsePrefix("10.71.22.160/27"))
+	rangeConfig, err := newIPv4Range(netip.MustParsePrefix("10.71.22.160/27"), 4)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -73,7 +73,7 @@ func TestAllocateReuseAndRoleSeparation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if got, want := worker1.String(), "10.71.22.171"; got != want {
+	if got, want := worker1.String(), "10.71.22.166"; got != want {
 		t.Fatalf("unexpected first worker ip: got %q, want %q", got, want)
 	}
 
@@ -107,14 +107,16 @@ func TestAllocateReuseAndRoleSeparation(t *testing.T) {
 func TestControlPlaneReserveExhaustion(t *testing.T) {
 	t.Parallel()
 
-	rangeConfig, err := newIPv4Range(netip.MustParsePrefix("10.71.22.160/27"))
+	const controlPlaneReserved = 4
+
+	rangeConfig, err := newIPv4Range(netip.MustParsePrefix("10.71.22.160/27"), controlPlaneReserved)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
 	state := newIPAMState()
 
-	for i := 0; i < reservedControlPlaneIPs; i++ {
+	for i := 0; i < controlPlaneReserved; i++ {
 		ip, allocErr := state.allocate(true, rangeConfig)
 		if allocErr != nil {
 			t.Fatalf("expected allocation to succeed on slot %d: %v", i, allocErr)
@@ -126,6 +128,23 @@ func TestControlPlaneReserveExhaustion(t *testing.T) {
 	_, err = state.allocate(true, rangeConfig)
 	if !errors.Is(err, errNoControlPlaneIPsAvailable) {
 		t.Fatalf("expected errNoControlPlaneIPsAvailable, got %v", err)
+	}
+}
+
+func TestNewIPv4RangeHonorsDynamicControlPlaneReserve(t *testing.T) {
+	t.Parallel()
+
+	rangeConfig, err := newIPv4Range(netip.MustParsePrefix("10.71.22.160/27"), 2)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if got, want := uint32ToIPv4(rangeConfig.controlPlaneEnd).String(), "10.71.22.163"; got != want {
+		t.Fatalf("unexpected controlPlaneEnd for reserve=2: got %q, want %q", got, want)
+	}
+
+	if got, want := uint32ToIPv4(rangeConfig.workerStart).String(), "10.71.22.164"; got != want {
+		t.Fatalf("unexpected workerStart for reserve=2: got %q, want %q", got, want)
 	}
 }
 

--- a/controllers/dockyardsmachineip_controller_test.go
+++ b/controllers/dockyardsmachineip_controller_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"errors"
+	"net/netip"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
+)
+
+func TestNewIPv4Range(t *testing.T) {
+	t.Parallel()
+
+	prefix := netip.MustParsePrefix("10.71.22.160/27")
+	rangeConfig, err := newIPv4Range(prefix)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if got, want := uint32ToIPv4(rangeConfig.controlPlaneStart).String(), "10.71.22.162"; got != want {
+		t.Fatalf("unexpected controlPlaneStart: got %q, want %q", got, want)
+	}
+
+	if got, want := uint32ToIPv4(rangeConfig.controlPlaneEnd).String(), "10.71.22.170"; got != want {
+		t.Fatalf("unexpected controlPlaneEnd: got %q, want %q", got, want)
+	}
+
+	if got, want := uint32ToIPv4(rangeConfig.workerStart).String(), "10.71.22.171"; got != want {
+		t.Fatalf("unexpected workerStart: got %q, want %q", got, want)
+	}
+
+	if got, want := uint32ToIPv4(rangeConfig.workerEnd).String(), "10.71.22.190"; got != want {
+		t.Fatalf("unexpected workerEnd: got %q, want %q", got, want)
+	}
+}
+
+func TestAllocateReuseAndRoleSeparation(t *testing.T) {
+	t.Parallel()
+
+	rangeConfig, err := newIPv4Range(netip.MustParsePrefix("10.71.22.160/27"))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	state := newIPAMState()
+
+	cp1, err := state.allocate(true, rangeConfig)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got, want := cp1.String(), "10.71.22.162"; got != want {
+		t.Fatalf("unexpected first cp ip: got %q, want %q", got, want)
+	}
+
+	state.Leases["cp-1"] = ipLease{IP: cp1, ControlPlane: true}
+
+	worker1, err := state.allocate(false, rangeConfig)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got, want := worker1.String(), "10.71.22.171"; got != want {
+		t.Fatalf("unexpected first worker ip: got %q, want %q", got, want)
+	}
+
+	state.Leases["worker-1"] = ipLease{IP: worker1, ControlPlane: false}
+
+	delete(state.Leases, "worker-1")
+	state.release(ipLease{IP: worker1, ControlPlane: false}, rangeConfig)
+
+	worker2, err := state.allocate(false, rangeConfig)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got, want := worker2.String(), worker1.String(); got != want {
+		t.Fatalf("expected released worker ip to be reused, got %q want %q", got, want)
+	}
+
+	state.Leases["worker-2"] = ipLease{IP: worker2, ControlPlane: false}
+
+	delete(state.Leases, "cp-1")
+	state.release(ipLease{IP: cp1, ControlPlane: true}, rangeConfig)
+
+	cp2, err := state.allocate(true, rangeConfig)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got, want := cp2.String(), cp1.String(); got != want {
+		t.Fatalf("expected released cp ip to be reused, got %q want %q", got, want)
+	}
+}
+
+func TestControlPlaneReserveExhaustion(t *testing.T) {
+	t.Parallel()
+
+	rangeConfig, err := newIPv4Range(netip.MustParsePrefix("10.71.22.160/27"))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	state := newIPAMState()
+
+	for i := 0; i < reservedControlPlaneIPs; i++ {
+		ip, allocErr := state.allocate(true, rangeConfig)
+		if allocErr != nil {
+			t.Fatalf("expected allocation to succeed on slot %d: %v", i, allocErr)
+		}
+
+		state.Leases["cp-"+ip.String()] = ipLease{IP: ip, ControlPlane: true}
+	}
+
+	_, err = state.allocate(true, rangeConfig)
+	if !errors.Is(err, errNoControlPlaneIPsAvailable) {
+		t.Fatalf("expected errNoControlPlaneIPsAvailable, got %v", err)
+	}
+}
+
+func TestUpsertLinkConfigPatch(t *testing.T) {
+	t.Parallel()
+
+	patches := []string{}
+	result, changed, err := upsertLinkConfigPatch(patches, "eth1", "10.71.22.171/27")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !changed {
+		t.Fatal("expected patch list to change")
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 patch, got %d", len(result))
+	}
+
+	result, changed, err = upsertLinkConfigPatch(result, "eth1", "10.71.22.171/27")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if changed {
+		t.Fatal("expected idempotent upsert to not change")
+	}
+}
+
+func TestUpsertLinkConfigPatchPreservesRoutes(t *testing.T) {
+	t.Parallel()
+
+	patches := []string{`apiVersion: v1alpha1
+kind: LinkConfig
+name: eth1
+routes:
+  - destination: 0.0.0.0/0
+    gateway: 10.71.22.161
+addresses:
+  - address: 10.71.22.172/27
+`}
+
+	result, changed, err := upsertLinkConfigPatch(patches, "eth1", "10.71.22.173/27")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !changed {
+		t.Fatal("expected patch list to change")
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 patch, got %d", len(result))
+	}
+
+	doc := map[string]any{}
+	if err := yaml.Unmarshal([]byte(result[0]), &doc); err != nil {
+		t.Fatalf("failed to unmarshal patch: %v", err)
+	}
+
+	routes, found, err := unstructured.NestedSlice(doc, "routes")
+	if err != nil || !found || len(routes) != 1 {
+		t.Fatalf("expected routes to be preserved")
+	}
+
+	addressEntries, found, err := unstructured.NestedSlice(doc, "addresses")
+	if err != nil || !found || len(addressEntries) != 1 {
+		t.Fatalf("expected exactly one address")
+	}
+
+	addr := addressEntries[0].(map[string]any)
+	if got, ok := addr["address"].(string); !ok || got != "10.71.22.173/27" {
+		t.Fatalf("unexpected updated address: %v", addr["address"])
+	}
+}
+
+func TestUpsertLinkConfigPatchPreservesUnmanagedAddresses(t *testing.T) {
+	t.Parallel()
+
+	patches := []string{`apiVersion: v1alpha1
+kind: LinkConfig
+name: eth1
+addresses:
+  - address: 10.71.22.172/27
+  - address: 192.168.10.5/24
+`}
+
+	result, changed, err := upsertLinkConfigPatch(patches, "eth1", "10.71.22.173/27")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !changed {
+		t.Fatal("expected patch list to change")
+	}
+
+	doc := map[string]any{}
+	if err := yaml.Unmarshal([]byte(result[0]), &doc); err != nil {
+		t.Fatalf("failed to unmarshal patch: %v", err)
+	}
+
+	addressEntries, found, err := unstructured.NestedSlice(doc, "addresses")
+	if err != nil || !found || len(addressEntries) != 2 {
+		t.Fatalf("expected exactly two addresses")
+	}
+
+	actual := map[string]bool{}
+	for _, entry := range addressEntries {
+		addr := entry.(map[string]any)
+		actual[addr["address"].(string)] = true
+	}
+
+	if !actual["10.71.22.173/27"] {
+		t.Fatalf("expected managed address to be updated")
+	}
+
+	if !actual["192.168.10.5/24"] {
+		t.Fatalf("expected unmanaged address to be preserved")
+	}
+}
+
+func TestUpsertLinkConfigPatchPreservesExplicitUp(t *testing.T) {
+	t.Parallel()
+
+	patches := []string{`apiVersion: v1alpha1
+kind: LinkConfig
+name: eth1
+up: false
+addresses:
+  - address: 10.71.22.172/27
+`}
+
+	result, _, err := upsertLinkConfigPatch(patches, "eth1", "10.71.22.173/27")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	doc := map[string]any{}
+	if err := yaml.Unmarshal([]byte(result[0]), &doc); err != nil {
+		t.Fatalf("failed to unmarshal patch: %v", err)
+	}
+
+	up, found, err := unstructured.NestedBool(doc, "up")
+	if err != nil || !found {
+		t.Fatalf("expected up value")
+	}
+
+	if up {
+		t.Fatalf("expected explicit up=false to be preserved")
+	}
+}

--- a/controllers/dockyardsmachineip_controller_test.go
+++ b/controllers/dockyardsmachineip_controller_test.go
@@ -163,7 +163,7 @@ func TestUpsertLinkConfigPatch(t *testing.T) {
 		t.Fatalf("expected 1 patch, got %d", len(result))
 	}
 
-	result, changed, err = upsertLinkConfigPatch(result, "eth1", "10.71.22.171/27")
+	_, changed, err = upsertLinkConfigPatch(result, "eth1", "10.71.22.171/27")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -149,13 +149,13 @@ func main() {
 	}
 
 	err = (&controllers.DockyardsNodePoolReconciler{
-		Client:                                 mgr.GetClient(),
-		TalosClusterDiscoveryServiceEndpoint:   talosClusterDiscoveryServiceEndpoint,
-		DataVolumeStorageClassName:             &dataVolumeStorageClassName,
-		EnableMultus:                           enableMultus,
-		UseBlockStorage:                        useBlockStorage,
-		ValidNodeIPSubnets:                     validNodeIPSubnets,
-		DockyardsConfig:                        dockyardsConfig,
+		Client:                               mgr.GetClient(),
+		TalosClusterDiscoveryServiceEndpoint: talosClusterDiscoveryServiceEndpoint,
+		DataVolumeStorageClassName:           &dataVolumeStorageClassName,
+		EnableMultus:                         enableMultus,
+		UseBlockStorage:                      useBlockStorage,
+		ValidNodeIPSubnets:                   validNodeIPSubnets,
+		DockyardsConfig:                      dockyardsConfig,
 	}).SetupWithManager(mgr)
 	if err != nil {
 		slogr.Error(err, "error creating dockyards node pool reconciler")
@@ -173,11 +173,11 @@ func main() {
 	}
 
 	err = (&controllers.DockyardsClusterReconciler{
-		Client:                 mgr.GetClient(),
-		GatewayParentReference: gatewayParentReference,
+		Client:                   mgr.GetClient(),
+		GatewayParentReference:   gatewayParentReference,
 		DockyardsSystemNamespace: dockyardsSystemNamespace,
-		DockyardsConfig:        dockyardsConfig,
-		EnableWorkloadIngress:  enableWorkloadIngress,
+		DockyardsConfig:          dockyardsConfig,
+		EnableWorkloadIngress:    enableWorkloadIngress,
 	}).SetupWithManager(mgr)
 	if err != nil {
 		slogr.Error(err, "error creating dockyards cluster reconciler")
@@ -201,6 +201,15 @@ func main() {
 	}).SetupWithManager(mgr)
 	if err != nil {
 		slogr.Error(err, "error creating dockyards node reconciler")
+	}
+
+	err = (&controllers.DockyardsMachineIPReconciler{
+		Client: mgr.GetClient(),
+	}).SetupWithManager(mgr)
+	if err != nil {
+		slogr.Error(err, "error creating dockyards machine IP reconciler")
+
+		os.Exit(1)
 	}
 
 	err = (&controllers.DockyardsReleaseReconciler{


### PR DESCRIPTION
- **Add machine-level external IPv4 allocation for Talos bootstrap**
- **Use TalosControlPlane replicas for IP reservation**
- **Patch bootstrap secret instead of immutable TalosConfig spec**
