### PR TITLE
StorageClass and Gateway changes based on upstream CRDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,28 @@ The controller stack keeps the KubeVirt and Talos artifacts aligned with the Doc
 - The release reconcilier creates/updates a CDI `DataVolume` and downstream `DataSource` that hold the latest Talos installer payload.
 - The node reconciler reads each `KubevirtMachine` to publish resource totals back into the Dockyards nodes.
 
+#### Per-cluster root disk storage class
+
+By default, root and additional VM disks use the global `--data-volume-storage-class-name` value.
+
+To override this per Dockyards cluster, set `spec.advanced.kubevirt.dataVolumeStorageClassName` on the owning `dockyards.io/v1alpha3 Cluster`:
+
+```yaml
+apiVersion: dockyards.io/v1alpha3
+kind: Cluster
+metadata:
+  name: example
+  namespace: customer-a
+spec:
+  advanced:
+    kubevirt:
+      dataVolumeStorageClassName: fast-ceph-block
+```
+
+Notes:
+- This affects root and additional VM disks created from NodePool machine templates.
+- Talos installer cache `DataVolume`s created by `DockyardsReleaseReconciler` still use the global setting.
+
 ### Workload ingress and Gateway API integration
 `DockyardsWorkloadReconciler` grants the shared gateway the HTTP/TLS routes and core/v1 services that front a workload cluster service. It uses `clustercache.ClusterCache` to watch the remote services that the workload cluster creates and patches their LoadBalancer IPs so that the management cluster service status always advertises the gateway address. Once the gateway has an address the reconciler builds HTTPRoute/TLSRoute objects that advertise every customer DNS zone recorded on the owning Dockyards cluster, keeping the gateway in sync with the workload for both HTTP and TLS traffic.
 
@@ -141,6 +163,8 @@ The controller reads selected keys from the Dockyards ConfigMap (configured via 
 1. Build/push `dockyards-kubevirt` and update the OCI repository referenced by the Dockyards installer (`dockyardsctl` already points to `public.ecr.aws/sudosweden/dockyards-kubevirt`).
 2. Deploy the controller into a cluster where `dockyards-system` hosts the Dockyards CRDs, Gateway, Talos providers, and the shared gateway; configure the CLI flags (`--config-map`, `--gateway-name`, `--gateway-namespace`, `--dockyards-namespace`, etc.) to match your installation.
 3. Ensure the Talos release data sources and `NodePool` specs match the storage classes and networks you expose to KubeVirt so that machine templates and Talos configs can be generated automatically.
+
+Note: if a specific Dockyards cluster should use a different root disk storage class than the global `--data-volume-storage-class-name`, set `spec.advanced.kubevirt.dataVolumeStorageClassName` on that cluster.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,30 @@ Notes:
 ### Workload ingress and Gateway API integration
 `DockyardsWorkloadReconciler` grants the shared gateway the HTTP/TLS routes and core/v1 services that front a workload cluster service. It uses `clustercache.ClusterCache` to watch the remote services that the workload cluster creates and patches their LoadBalancer IPs so that the management cluster service status always advertises the gateway address. Once the gateway has an address the reconciler builds HTTPRoute/TLSRoute objects that advertise every customer DNS zone recorded on the owning Dockyards cluster, keeping the gateway in sync with the workload for both HTTP and TLS traffic.
 
+#### Per-cluster workload gateway parentRef
+
+By default, workload `HTTPRoute`/`TLSRoute` resources use the global `--gateway-name` and `--gateway-namespace` values.
+
+To override this per Dockyards cluster, set `spec.advanced.gateway.parentRef` on the owning `dockyards.io/v1alpha3 Cluster`:
+
+```yaml
+apiVersion: dockyards.io/v1alpha3
+kind: Cluster
+metadata:
+  name: example
+  namespace: customer-a
+spec:
+  advanced:
+    gateway:
+      parentRef:
+        name: tenant-gateway
+        namespace: tenant-gateway-system
+```
+
+Notes:
+- Both `name` and `namespace` must be set; if either is missing/empty the controller falls back to the global gateway flags.
+- This override applies to workload route parent refs and gateway lookup in `DockyardsWorkloadReconciler`.
+
 `DockyardsClusterReconciler` also ensures the workload cluster has a default ingress controller by creating a per-cluster Dockyards `Workload` named `<cluster>-ingress-nginx` using the `ingress-nginx` `WorkloadTemplate` in the configured public namespace.
 
 - Set `Cluster.spec.noDefaultIngressProvider: true` to skip creating/patching that default `ingress-nginx` workload.
@@ -165,6 +189,8 @@ The controller reads selected keys from the Dockyards ConfigMap (configured via 
 3. Ensure the Talos release data sources and `NodePool` specs match the storage classes and networks you expose to KubeVirt so that machine templates and Talos configs can be generated automatically.
 
 Note: if a specific Dockyards cluster should use a different root disk storage class than the global `--data-volume-storage-class-name`, set `spec.advanced.kubevirt.dataVolumeStorageClassName` on that cluster.
+
+Note: if a specific Dockyards cluster should bind workload `HTTPRoute`/`TLSRoute` to a different Gateway than the global `--gateway-name`/`--gateway-namespace`, set `spec.advanced.gateway.parentRef.name` and `spec.advanced.gateway.parentRef.namespace`.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,29 @@ Notes:
 - This affects root and additional VM disks created from NodePool machine templates.
 - Talos installer cache `DataVolume`s created by `DockyardsReleaseReconciler` still use the global setting.
 
+#### Per-nodepool taints
+
+To apply Kubernetes node taints per NodePool, set `spec.nodeTaints` on the `dockyards.io/v1alpha3 NodePool`.
+
+```yaml
+apiVersion: dockyards.io/v1alpha3
+kind: NodePool
+metadata:
+  name: workers
+  namespace: customer-a
+spec:
+  nodeTaints:
+    node-role.kubernetes.io/worker: "hz:NoSchedule"
+    node.kubernetes.io/unreachable: ":NoExecute"
+```
+
+Notes:
+- Values must be formatted as `<value>:<effect>`.
+- `effect` must be one of `NoSchedule`, `PreferNoSchedule`, or `NoExecute`.
+- Empty taint values are allowed by using `:<effect>`.
+- The legacy object format (`value`/`effect`) is not supported.
+- Invalid taints return a reconciliation error.
+
 ### Workload ingress and Gateway API integration
 `DockyardsWorkloadReconciler` grants the shared gateway the HTTP/TLS routes and core/v1 services that front a workload cluster service. It uses `clustercache.ClusterCache` to watch the remote services that the workload cluster creates and patches their LoadBalancer IPs so that the management cluster service status always advertises the gateway address. Once the gateway has an address the reconciler builds HTTPRoute/TLSRoute objects that advertise every customer DNS zone recorded on the owning Dockyards cluster, keeping the gateway in sync with the workload for both HTTP and TLS traffic.
 

--- a/api/v1alpha1/dockyardsipamclaim_types.go
+++ b/api/v1alpha1/dockyardsipamclaim_types.go
@@ -31,6 +31,8 @@ type DockyardsIPAMClaimSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=ipamclaims,scope=Namespaced,categories=dockyards
+// +kubebuilder:printcolumn:name="Address",type=string,JSONPath=".spec.address"
+// +kubebuilder:printcolumn:name="Subnet",type=string,JSONPath=".spec.subnet"
 
 // DockyardsIPAMClaim is the schema for Dockyards IPAM claims.
 type DockyardsIPAMClaim struct {

--- a/api/v1alpha1/dockyardsipamclaim_types.go
+++ b/api/v1alpha1/dockyardsipamclaim_types.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// DockyardsIPAMClaimSpec defines desired state of DockyardsIPAMClaim.
+type DockyardsIPAMClaimSpec struct {
+	ClusterName  string `json:"clusterName"`
+	MachineName  string `json:"machineName"`
+	Interface    string `json:"interface"`
+	Subnet       string `json:"subnet"`
+	ControlPlane bool   `json:"controlPlane"`
+	Address      string `json:"address,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+// +kubebuilder:resource:path=dockyardsipamclaims,scope=Namespaced,categories=dockyards
+
+// DockyardsIPAMClaim is the schema for Dockyards IPAM claims.
+type DockyardsIPAMClaim struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec DockyardsIPAMClaimSpec `json:"spec,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// DockyardsIPAMClaimList contains a list of DockyardsIPAMClaim.
+type DockyardsIPAMClaimList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []DockyardsIPAMClaim `json:"items"`
+}
+
+func (in *DockyardsIPAMClaim) DeepCopyInto(out *DockyardsIPAMClaim) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	out.Spec = in.Spec
+}
+
+func (in *DockyardsIPAMClaim) DeepCopy() *DockyardsIPAMClaim {
+	if in == nil {
+		return nil
+	}
+
+	out := new(DockyardsIPAMClaim)
+	in.DeepCopyInto(out)
+
+	return out
+}
+
+func (in *DockyardsIPAMClaim) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+
+	return nil
+}
+
+func (in *DockyardsIPAMClaimList) DeepCopyInto(out *DockyardsIPAMClaimList) {
+	*out = *in
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		in, out := &in.Items, &out.Items
+		*out = make([]DockyardsIPAMClaim, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+}
+
+func (in *DockyardsIPAMClaimList) DeepCopy() *DockyardsIPAMClaimList {
+	if in == nil {
+		return nil
+	}
+
+	out := new(DockyardsIPAMClaimList)
+	in.DeepCopyInto(out)
+
+	return out
+}
+
+func (in *DockyardsIPAMClaimList) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+
+	return nil
+}

--- a/api/v1alpha1/dockyardsipamclaim_types.go
+++ b/api/v1alpha1/dockyardsipamclaim_types.go
@@ -30,7 +30,7 @@ type DockyardsIPAMClaimSpec struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=dockyardsipamclaims,scope=Namespaced,categories=dockyards
+// +kubebuilder:resource:path=ipamclaims,scope=Namespaced,categories=dockyards
 
 // DockyardsIPAMClaim is the schema for Dockyards IPAM claims.
 type DockyardsIPAMClaim struct {

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var (
+	// GroupVersion is group version used to register these objects.
+	GroupVersion = schema.GroupVersion{Group: "kubevirt.dockyards.io", Version: "v1alpha1"}
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
+
+	// AddToScheme adds all resources in this group-version to the provided scheme.
+	AddToScheme = SchemeBuilder.AddToScheme
+)
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(
+		GroupVersion,
+		&DockyardsIPAMClaim{},
+		&DockyardsIPAMClaimList{},
+	)
+
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+
+	return nil
+}

--- a/config/base/dockyardsipamclaim-crd.yaml
+++ b/config/base/dockyardsipamclaim-crd.yaml
@@ -15,14 +15,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: dockyardsipamclaims.kubevirt.dockyards.io
+  name: ipamclaims.kubevirt.dockyards.io
 spec:
   group: kubevirt.dockyards.io
   names:
     kind: DockyardsIPAMClaim
     listKind: DockyardsIPAMClaimList
-    plural: dockyardsipamclaims
-    singular: dockyardsipamclaim
+    plural: ipamclaims
+    singular: ipamclaim
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/config/base/dockyardsipamclaim-crd.yaml
+++ b/config/base/dockyardsipamclaim-crd.yaml
@@ -28,6 +28,13 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+    additionalPrinterColumns:
+    - name: Address
+      type: string
+      jsonPath: .spec.address
+    - name: Subnet
+      type: string
+      jsonPath: .spec.subnet
     schema:
       openAPIV3Schema:
         type: object

--- a/config/base/dockyardsipamclaim-crd.yaml
+++ b/config/base/dockyardsipamclaim-crd.yaml
@@ -1,0 +1,55 @@
+# Copyright 2026 Sudo Sweden AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: dockyardsipamclaims.kubevirt.dockyards.io
+spec:
+  group: kubevirt.dockyards.io
+  names:
+    kind: DockyardsIPAMClaim
+    listKind: DockyardsIPAMClaimList
+    plural: dockyardsipamclaims
+    singular: dockyardsipamclaim
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            required:
+            - clusterName
+            - machineName
+            - interface
+            - subnet
+            - controlPlane
+            properties:
+              clusterName:
+                type: string
+              machineName:
+                type: string
+              interface:
+                type: string
+              subnet:
+                type: string
+              controlPlane:
+                type: boolean
+              address:
+                type: string

--- a/config/base/kustomization.yaml
+++ b/config/base/kustomization.yaml
@@ -15,6 +15,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- dockyardsipamclaim-crd.yaml
 - deployment.yaml
 - serviceaccount.yaml
 - clusterrolebinding.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,17 +21,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - get
@@ -281,30 +270,21 @@ rules:
 - apiGroups:
   - k8s.cni.cncf.io
   resources:
-  - ipamclaims
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - k8s.cni.cncf.io
-  resources:
-  - ipamclaims/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - k8s.cni.cncf.io
-  resources:
   - network-attachment-definitions
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - kubevirt.dockyards.io
+  resources:
+  - dockyardsipamclaims
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -278,7 +278,7 @@ rules:
 - apiGroups:
   - kubevirt.dockyards.io
   resources:
-  - dockyardsipamclaims
+  - ipamclaims
   verbs:
   - create
   - get

--- a/controllers/dockyardsmachineip_controller.go
+++ b/controllers/dockyardsmachineip_controller.go
@@ -17,7 +17,6 @@ package controllers
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -28,14 +27,13 @@ import (
 	bootstrapv1 "github.com/siderolabs/cluster-api-bootstrap-provider-talos/api/v1alpha3"
 	controlplanev1 "github.com/siderolabs/cluster-api-control-plane-provider-talos/api/v1alpha3"
 	dockyardsv1 "github.com/sudoswedenab/dockyards-backend/api/v1alpha3"
+	dockyardskubevirtv1 "github.com/sudoswedenab/dockyards-kubevirt/api/v1alpha1"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,12 +41,6 @@ import (
 )
 
 const (
-	ipamClaimAPIVersion = "k8s.cni.cncf.io/v1alpha1"
-	ipamClaimKind       = "IPAMClaim"
-
-	ipamStateConfigMapSuffix = "-external-node-ipam-state"
-	ipamStateConfigMapKey    = "state.json"
-
 	defaultExternalNodeInterface = "eth1"
 	defaultControlPlaneReplicas  = 1
 
@@ -60,13 +52,11 @@ var (
 	errNoControlPlaneIPsAvailable = errors.New("no control plane IPs available")
 )
 
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=create;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;patch;update;watch
 // +kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=talosconfigs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines,verbs=delete;get;list;watch
 // +kubebuilder:rbac:groups=dockyards.io,resources=clusters,verbs=get;list;watch
-// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=ipamclaims,verbs=create;delete;get;list;patch;update;watch
-// +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=ipamclaims/status,verbs=get;patch;update
+// +kubebuilder:rbac:groups=kubevirt.dockyards.io,resources=dockyardsipamclaims,verbs=create;get;list;patch;update;watch
 
 type DockyardsMachineIPReconciler struct {
 	client.Client
@@ -109,37 +99,24 @@ func (r *DockyardsMachineIPReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, err
 	}
 
-	machineKey := machine.Name
 	isControlPlane := machineIsControlPlane(&machine)
-	stateName := clusterKey.Name + ipamStateConfigMapSuffix
-
-	if err := r.garbageCollectLeases(ctx, clusterKey.Namespace, clusterKey.Name, stateName, clusterRange); err != nil {
-		return ctrl.Result{}, err
-	}
 
 	if !machine.DeletionTimestamp.IsZero() {
-		if err := r.releaseMachineIP(ctx, clusterKey.Namespace, stateName, machineKey, clusterRange); err != nil {
-			return ctrl.Result{}, err
-		}
-
-		if err := r.deleteIPAMClaim(ctx, machine.Namespace, machineIPAMClaimName(machine.Name)); err != nil {
-			return ctrl.Result{}, err
-		}
-
 		return ctrl.Result{}, nil
 	}
 
-	ip, err := r.allocateMachineIP(ctx, clusterKey.Namespace, stateName, machineKey, isControlPlane, clusterRange)
+	claim, err := r.ensureDockyardsIPAMClaim(ctx, &machine, clusterKey.Name, config.Interface, config.Subnet, isControlPlane)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	ip, err := r.ensureClaimAddress(ctx, claim, clusterRange)
 	if err != nil {
 		if errors.Is(err, errNoControlPlaneIPsAvailable) || errors.Is(err, errNoWorkerIPsAvailable) {
 			logger.Info("unable to allocate IP", "machine", machine.Name, "cluster", clusterKey.Name, "error", err)
 			return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 		}
 
-		return ctrl.Result{}, err
-	}
-
-	if err := r.ensureIPAMClaim(ctx, machine.Namespace, machineIPAMClaimName(machine.Name), clusterKey.Name, config.Interface, ip); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -326,199 +303,178 @@ func (r *DockyardsMachineIPReconciler) desiredControlPlaneReplicas(ctx context.C
 	return replicas, nil
 }
 
-func (r *DockyardsMachineIPReconciler) ensureIPAMClaim(ctx context.Context, namespace, claimName, networkName, ifName string, ip netip.Addr) error {
-	claim := &unstructured.Unstructured{}
-	claim.SetGroupVersionKind(schema.GroupVersionKind{Group: "k8s.cni.cncf.io", Version: "v1alpha1", Kind: ipamClaimKind})
-
-	key := types.NamespacedName{Namespace: namespace, Name: claimName}
-	err := r.Get(ctx, key, claim)
+func (r *DockyardsMachineIPReconciler) ensureDockyardsIPAMClaim(
+	ctx context.Context,
+	machine *clusterv1.Machine,
+	clusterName,
+	ifName string,
+	subnet netip.Prefix,
+	controlPlane bool,
+) (*dockyardskubevirtv1.DockyardsIPAMClaim, error) {
+	claimKey := types.NamespacedName{Namespace: machine.Namespace, Name: machineIPAMClaimName(machine.Name)}
+	claim := &dockyardskubevirtv1.DockyardsIPAMClaim{}
+	err := r.Get(ctx, claimKey, claim)
 	if apierrors.IsNotFound(err) {
-		claim.SetNamespace(namespace)
-		claim.SetName(claimName)
-		claim.Object["spec"] = map[string]any{
-			"network":   networkName,
-			"interface": ifName,
+		claim = &dockyardskubevirtv1.DockyardsIPAMClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: machine.Namespace,
+				Name:      machineIPAMClaimName(machine.Name),
+				OwnerReferences: []metav1.OwnerReference{
+					machineOwnerReference(machine),
+				},
+			},
+			Spec: dockyardskubevirtv1.DockyardsIPAMClaimSpec{
+				ClusterName:  clusterName,
+				MachineName:  machine.Name,
+				Interface:    ifName,
+				Subnet:       subnet.String(),
+				ControlPlane: controlPlane,
+			},
 		}
 
 		if err := r.Create(ctx, claim); err != nil {
-			return err
+			return nil, err
 		}
-	} else if err != nil {
-		return err
+
+		return claim, nil
 	}
 
-	statusIPs, found, err := unstructured.NestedStringSlice(claim.Object, "status", "ips")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if found && len(statusIPs) == 1 && statusIPs[0] == ip.String() {
-		return nil
+	patch := client.MergeFrom(claim.DeepCopy())
+	changed := false
+
+	if claim.Spec.ClusterName != clusterName {
+		claim.Spec.ClusterName = clusterName
+		changed = true
 	}
 
-	statusPatch := claim.DeepCopy()
-	if err := unstructured.SetNestedStringSlice(statusPatch.Object, []string{ip.String()}, "status", "ips"); err != nil {
-		return err
+	if claim.Spec.MachineName != machine.Name {
+		claim.Spec.MachineName = machine.Name
+		changed = true
 	}
 
-	return r.Status().Patch(ctx, statusPatch, client.MergeFrom(claim))
+	if claim.Spec.Interface != ifName {
+		claim.Spec.Interface = ifName
+		changed = true
+	}
+
+	if claim.Spec.Subnet != subnet.String() {
+		claim.Spec.Subnet = subnet.String()
+		changed = true
+	}
+
+	if claim.Spec.ControlPlane != controlPlane {
+		claim.Spec.ControlPlane = controlPlane
+		changed = true
+	}
+
+	if !machineOwnerReferenceExists(claim.OwnerReferences, machine.UID) {
+		claim.OwnerReferences = []metav1.OwnerReference{machineOwnerReference(machine)}
+		changed = true
+	}
+
+	if changed {
+		if err := r.Patch(ctx, claim, patch); err != nil {
+			return nil, err
+		}
+	}
+
+	return claim, nil
 }
 
-func (r *DockyardsMachineIPReconciler) deleteIPAMClaim(ctx context.Context, namespace, claimName string) error {
-	claim := &unstructured.Unstructured{}
-	claim.SetGroupVersionKind(schema.GroupVersionKind{Group: "k8s.cni.cncf.io", Version: "v1alpha1", Kind: ipamClaimKind})
+func (r *DockyardsMachineIPReconciler) ensureClaimAddress(ctx context.Context, claim *dockyardskubevirtv1.DockyardsIPAMClaim, subnet ipv4Range) (netip.Addr, error) {
+	if claim.Spec.Address != "" {
+		ip, err := netip.ParseAddr(claim.Spec.Address)
+		if err != nil {
+			return netip.Addr{}, fmt.Errorf("invalid dockyards ipam claim address %q: %w", claim.Spec.Address, err)
+		}
 
-	err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: claimName}, claim)
-	if err != nil {
-		return client.IgnoreNotFound(err)
+		if !ip.Is4() {
+			return netip.Addr{}, fmt.Errorf("invalid non-ipv4 address in dockyards ipam claim: %q", claim.Spec.Address)
+		}
+
+		return ip, nil
 	}
 
-	return client.IgnoreNotFound(r.Delete(ctx, claim))
-}
-
-func (r *DockyardsMachineIPReconciler) allocateMachineIP(ctx context.Context, namespace, stateName, machineKey string, isControlPlane bool, subnet ipv4Range) (netip.Addr, error) {
-	var allocated netip.Addr
-
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		configMap, state, err := r.getOrCreateStateConfigMap(ctx, namespace, stateName)
-		if err != nil {
-			return err
-		}
-
-		if lease, ok := state.Leases[machineKey]; ok {
-			allocated = lease.IP
-			return nil
-		}
-
-		ip, err := state.allocate(isControlPlane, subnet)
-		if err != nil {
-			return err
-		}
-
-		state.Leases[machineKey] = ipLease{IP: ip, ControlPlane: isControlPlane}
-		allocated = ip
-
-		if err := persistStateConfigMap(configMap, state); err != nil {
-			return err
-		}
-
-		return r.Update(ctx, configMap)
-	})
+	ip, err := r.allocateClaimAddress(ctx, claim.Namespace, claim.Name, claim.Spec.ClusterName, claim.Spec.ControlPlane, subnet)
 	if err != nil {
 		return netip.Addr{}, err
 	}
 
-	return allocated, nil
+	patch := client.MergeFrom(claim.DeepCopy())
+	claim.Spec.Address = ip.String()
+
+	if err := r.Patch(ctx, claim, patch); err != nil {
+		return netip.Addr{}, err
+	}
+
+	return ip, nil
 }
 
-func (r *DockyardsMachineIPReconciler) garbageCollectLeases(ctx context.Context, namespace, clusterName, stateName string, subnet ipv4Range) error {
-	var machineList clusterv1.MachineList
-
-	err := r.List(
-		ctx,
-		&machineList,
-		client.InNamespace(namespace),
-		client.MatchingLabels{clusterv1.ClusterNameLabel: clusterName},
-	)
+func (r *DockyardsMachineIPReconciler) allocateClaimAddress(
+	ctx context.Context,
+	namespace,
+	exceptClaimName,
+	clusterName string,
+	controlPlane bool,
+	subnet ipv4Range,
+) (netip.Addr, error) {
+	var claimList dockyardskubevirtv1.DockyardsIPAMClaimList
+	err := r.List(ctx, &claimList, client.InNamespace(namespace))
 	if err != nil {
-		return err
+		return netip.Addr{}, err
 	}
 
-	activeMachines := make(map[string]struct{}, len(machineList.Items))
-	for i := range machineList.Items {
-		activeMachines[machineList.Items[i].Name] = struct{}{}
-	}
-
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		configMap, state, err := r.getOrCreateStateConfigMap(ctx, namespace, stateName)
-		if err != nil {
-			return err
+	inUse := map[uint32]struct{}{}
+	for _, claim := range claimList.Items {
+		if claim.Name == exceptClaimName {
+			continue
 		}
 
-		changed := false
-		for machineName, lease := range state.Leases {
-			if _, ok := activeMachines[machineName]; ok {
+		if claim.Spec.ClusterName != clusterName || claim.Spec.Address == "" {
+			continue
+		}
+
+		ip, err := netip.ParseAddr(claim.Spec.Address)
+		if err != nil {
+			return netip.Addr{}, fmt.Errorf("invalid address %q in dockyards ipam claim %s/%s: %w", claim.Spec.Address, claim.Namespace, claim.Name, err)
+		}
+
+		if !ip.Is4() {
+			return netip.Addr{}, fmt.Errorf("non-ipv4 address %q in dockyards ipam claim %s/%s", claim.Spec.Address, claim.Namespace, claim.Name)
+		}
+
+		inUse[ipv4ToUint32(ip)] = struct{}{}
+	}
+
+	return nextAvailableIP(controlPlane, inUse, subnet)
+}
+
+func nextAvailableIP(controlPlane bool, inUse map[uint32]struct{}, subnet ipv4Range) (netip.Addr, error) {
+	if controlPlane {
+		for v := subnet.controlPlaneStart; v <= subnet.controlPlaneEnd; v++ {
+			if _, exists := inUse[v]; exists {
 				continue
 			}
 
-			delete(state.Leases, machineName)
-			state.release(lease, subnet)
-			changed = true
+			return uint32ToIPv4(v), nil
 		}
 
-		if !changed {
-			return nil
-		}
-
-		if err := persistStateConfigMap(configMap, state); err != nil {
-			return err
-		}
-
-		return r.Update(ctx, configMap)
-	})
-}
-
-func (r *DockyardsMachineIPReconciler) releaseMachineIP(ctx context.Context, namespace, stateName, machineKey string, subnet ipv4Range) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		configMap, state, err := r.getOrCreateStateConfigMap(ctx, namespace, stateName)
-		if err != nil {
-			return err
-		}
-
-		lease, ok := state.Leases[machineKey]
-		if !ok {
-			return nil
-		}
-
-		delete(state.Leases, machineKey)
-		state.release(lease, subnet)
-
-		if err := persistStateConfigMap(configMap, state); err != nil {
-			return err
-		}
-
-		return r.Update(ctx, configMap)
-	})
-}
-
-func (r *DockyardsMachineIPReconciler) getOrCreateStateConfigMap(ctx context.Context, namespace, name string) (*corev1.ConfigMap, *ipamState, error) {
-	configMap := &corev1.ConfigMap{}
-	key := types.NamespacedName{Namespace: namespace, Name: name}
-
-	err := r.Get(ctx, key, configMap)
-	if apierrors.IsNotFound(err) {
-		configMap = &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
-				Name:      name,
-			},
-			Data: map[string]string{},
-		}
-
-		state := newIPAMState()
-		if err := persistStateConfigMap(configMap, state); err != nil {
-			return nil, nil, err
-		}
-
-		if err := r.Create(ctx, configMap); err != nil {
-			if !apierrors.IsAlreadyExists(err) {
-				return nil, nil, err
-			}
-
-			if err := r.Get(ctx, key, configMap); err != nil {
-				return nil, nil, err
-			}
-		}
-	} else if err != nil {
-		return nil, nil, err
+		return netip.Addr{}, errNoControlPlaneIPsAvailable
 	}
 
-	state, err := parseIPAMState(configMap)
-	if err != nil {
-		return nil, nil, err
+	for v := subnet.workerStart; v <= subnet.workerEnd; v++ {
+		if _, exists := inUse[v]; exists {
+			continue
+		}
+
+		return uint32ToIPv4(v), nil
 	}
 
-	return configMap, state, nil
+	return netip.Addr{}, errNoWorkerIPsAvailable
 }
 
 func (r *DockyardsMachineIPReconciler) dockyardsClusterToMachines(ctx context.Context, obj client.Object) []ctrl.Request {
@@ -553,6 +509,7 @@ func (r *DockyardsMachineIPReconciler) SetupWithManager(m ctrl.Manager) error {
 	_ = bootstrapv1.AddToScheme(scheme)
 	_ = clusterv1.AddToScheme(scheme)
 	_ = controlplanev1.AddToScheme(scheme)
+	_ = dockyardskubevirtv1.AddToScheme(scheme)
 	_ = dockyardsv1.AddToScheme(scheme)
 
 	return ctrl.NewControllerManagedBy(m).
@@ -579,146 +536,28 @@ type externalNodeConfig struct {
 	Interface string
 }
 
-type ipLease struct {
-	IP           netip.Addr `json:"ip"`
-	ControlPlane bool       `json:"controlPlane"`
+func machineOwnerReference(machine *clusterv1.Machine) metav1.OwnerReference {
+	controller := false
+	blockOwnerDeletion := false
+
+	return metav1.OwnerReference{
+		APIVersion:         clusterv1.GroupVersion.String(),
+		Kind:               "Machine",
+		Name:               machine.Name,
+		UID:                machine.UID,
+		Controller:         &controller,
+		BlockOwnerDeletion: &blockOwnerDeletion,
+	}
 }
 
-type ipamState struct {
-	Leases               map[string]ipLease `json:"leases"`
-	ReleasedControlPlane []netip.Addr       `json:"releasedControlPlane"`
-	ReleasedWorker       []netip.Addr       `json:"releasedWorker"`
-}
-
-func newIPAMState() *ipamState {
-	return &ipamState{Leases: map[string]ipLease{}}
-}
-
-func parseIPAMState(configMap *corev1.ConfigMap) (*ipamState, error) {
-	if configMap.Data == nil {
-		return newIPAMState(), nil
-	}
-
-	raw, ok := configMap.Data[ipamStateConfigMapKey]
-	if !ok || raw == "" {
-		return newIPAMState(), nil
-	}
-
-	var state ipamState
-	if err := json.Unmarshal([]byte(raw), &state); err != nil {
-		return nil, err
-	}
-
-	if state.Leases == nil {
-		state.Leases = map[string]ipLease{}
-	}
-
-	return &state, nil
-}
-
-func persistStateConfigMap(configMap *corev1.ConfigMap, state *ipamState) error {
-	raw, err := json.Marshal(state)
-	if err != nil {
-		return err
-	}
-
-	if configMap.Data == nil {
-		configMap.Data = map[string]string{}
-	}
-
-	configMap.Data[ipamStateConfigMapKey] = string(raw)
-
-	return nil
-}
-
-func (s *ipamState) allocate(controlPlane bool, subnet ipv4Range) (netip.Addr, error) {
-	inUse := make(map[uint32]struct{}, len(s.Leases))
-	for _, lease := range s.Leases {
-		inUse[ipv4ToUint32(lease.IP)] = struct{}{}
-	}
-
-	if controlPlane {
-		addr, queue, ok := popReusableIP(s.ReleasedControlPlane, inUse, subnet.controlPlaneStart, subnet.controlPlaneEnd)
-		s.ReleasedControlPlane = queue
-		if ok {
-			return addr, nil
+func machineOwnerReferenceExists(ownerReferences []metav1.OwnerReference, uid types.UID) bool {
+	for _, ownerReference := range ownerReferences {
+		if ownerReference.UID == uid {
+			return true
 		}
-
-		for v := subnet.controlPlaneStart; v <= subnet.controlPlaneEnd; v++ {
-			if _, exists := inUse[v]; exists {
-				continue
-			}
-
-			return uint32ToIPv4(v), nil
-		}
-
-		return netip.Addr{}, errNoControlPlaneIPsAvailable
 	}
 
-	addr, queue, ok := popReusableIP(s.ReleasedWorker, inUse, subnet.workerStart, subnet.workerEnd)
-	s.ReleasedWorker = queue
-	if ok {
-		return addr, nil
-	}
-
-	for v := subnet.workerStart; v <= subnet.workerEnd; v++ {
-		if _, exists := inUse[v]; exists {
-			continue
-		}
-
-		return uint32ToIPv4(v), nil
-	}
-
-	return netip.Addr{}, errNoWorkerIPsAvailable
-}
-
-func (s *ipamState) release(lease ipLease, subnet ipv4Range) {
-	value := ipv4ToUint32(lease.IP)
-
-	if lease.ControlPlane {
-		if value < subnet.controlPlaneStart || value > subnet.controlPlaneEnd {
-			return
-		}
-
-		if slices.Contains(s.ReleasedControlPlane, lease.IP) {
-			return
-		}
-
-		s.ReleasedControlPlane = append(s.ReleasedControlPlane, lease.IP)
-
-		return
-	}
-
-	if value < subnet.workerStart || value > subnet.workerEnd {
-		return
-	}
-
-	if slices.Contains(s.ReleasedWorker, lease.IP) {
-		return
-	}
-
-	s.ReleasedWorker = append(s.ReleasedWorker, lease.IP)
-}
-
-func popReusableIP(queue []netip.Addr, inUse map[uint32]struct{}, start, end uint32) (netip.Addr, []netip.Addr, bool) {
-	for i, addr := range queue {
-		value := ipv4ToUint32(addr)
-		if value < start || value > end {
-			continue
-		}
-
-		if _, exists := inUse[value]; exists {
-			continue
-		}
-
-		remaining := make([]netip.Addr, 0, len(queue)-1)
-		remaining = append(remaining, queue[:i]...)
-		remaining = append(remaining, queue[i+1:]...)
-
-		return addr, remaining, true
-	}
-
-	return netip.Addr{}, queue, false
+	return false
 }
 
 type ipv4Range struct {

--- a/controllers/dockyardsmachineip_controller.go
+++ b/controllers/dockyardsmachineip_controller.go
@@ -56,7 +56,7 @@ var (
 // +kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=talosconfigs,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines,verbs=delete;get;list;watch
 // +kubebuilder:rbac:groups=dockyards.io,resources=clusters,verbs=get;list;watch
-// +kubebuilder:rbac:groups=kubevirt.dockyards.io,resources=dockyardsipamclaims,verbs=create;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=kubevirt.dockyards.io,resources=ipamclaims,verbs=create;get;list;patch;update;watch
 
 type DockyardsMachineIPReconciler struct {
 	client.Client

--- a/controllers/dockyardsmachineip_controller_test.go
+++ b/controllers/dockyardsmachineip_controller_test.go
@@ -49,7 +49,7 @@ func TestNewIPv4Range(t *testing.T) {
 	}
 }
 
-func TestAllocateReuseAndRoleSeparation(t *testing.T) {
+func TestNextAvailableIPRoleSeparation(t *testing.T) {
 	t.Parallel()
 
 	rangeConfig, err := newIPv4Range(netip.MustParsePrefix("10.71.22.160/27"), 4)
@@ -57,9 +57,9 @@ func TestAllocateReuseAndRoleSeparation(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	state := newIPAMState()
+	inUse := map[uint32]struct{}{}
 
-	cp1, err := state.allocate(true, rangeConfig)
+	cp1, err := nextAvailableIP(true, inUse, rangeConfig)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -67,9 +67,9 @@ func TestAllocateReuseAndRoleSeparation(t *testing.T) {
 		t.Fatalf("unexpected first cp ip: got %q, want %q", got, want)
 	}
 
-	state.Leases["cp-1"] = ipLease{IP: cp1, ControlPlane: true}
+	inUse[ipv4ToUint32(cp1)] = struct{}{}
 
-	worker1, err := state.allocate(false, rangeConfig)
+	worker1, err := nextAvailableIP(false, inUse, rangeConfig)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -77,30 +77,50 @@ func TestAllocateReuseAndRoleSeparation(t *testing.T) {
 		t.Fatalf("unexpected first worker ip: got %q, want %q", got, want)
 	}
 
-	state.Leases["worker-1"] = ipLease{IP: worker1, ControlPlane: false}
-
-	delete(state.Leases, "worker-1")
-	state.release(ipLease{IP: worker1, ControlPlane: false}, rangeConfig)
-
-	worker2, err := state.allocate(false, rangeConfig)
+	inUse[ipv4ToUint32(worker1)] = struct{}{}
+	worker2, err := nextAvailableIP(false, inUse, rangeConfig)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if got, want := worker2.String(), worker1.String(); got != want {
-		t.Fatalf("expected released worker ip to be reused, got %q want %q", got, want)
+	if got, want := worker2.String(), "10.71.22.167"; got != want {
+		t.Fatalf("expected next free worker ip, got %q want %q", got, want)
 	}
+}
 
-	state.Leases["worker-2"] = ipLease{IP: worker2, ControlPlane: false}
+func TestNextAvailableIPReusesAddressWhenClaimDisappears(t *testing.T) {
+	t.Parallel()
 
-	delete(state.Leases, "cp-1")
-	state.release(ipLease{IP: cp1, ControlPlane: true}, rangeConfig)
-
-	cp2, err := state.allocate(true, rangeConfig)
+	rangeConfig, err := newIPv4Range(netip.MustParsePrefix("10.71.22.160/27"), 4)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	if got, want := cp2.String(), cp1.String(); got != want {
-		t.Fatalf("expected released cp ip to be reused, got %q want %q", got, want)
+
+	inUse := map[uint32]struct{}{}
+
+	worker1, err := nextAvailableIP(false, inUse, rangeConfig)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	inUse[ipv4ToUint32(worker1)] = struct{}{}
+	worker2, err := nextAvailableIP(false, inUse, rangeConfig)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if got, want := worker2.String(), "10.71.22.167"; got != want {
+		t.Fatalf("unexpected second worker ip: got %q, want %q", got, want)
+	}
+
+	delete(inUse, ipv4ToUint32(worker1))
+
+	reused, err := nextAvailableIP(false, inUse, rangeConfig)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if got, want := reused.String(), worker1.String(); got != want {
+		t.Fatalf("expected disappeared claim ip to be reused, got %q want %q", got, want)
 	}
 }
 
@@ -114,18 +134,18 @@ func TestControlPlaneReserveExhaustion(t *testing.T) {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	state := newIPAMState()
+	inUse := map[uint32]struct{}{}
 
 	for i := 0; i < controlPlaneReserved; i++ {
-		ip, allocErr := state.allocate(true, rangeConfig)
+		ip, allocErr := nextAvailableIP(true, inUse, rangeConfig)
 		if allocErr != nil {
 			t.Fatalf("expected allocation to succeed on slot %d: %v", i, allocErr)
 		}
 
-		state.Leases["cp-"+ip.String()] = ipLease{IP: ip, ControlPlane: true}
+		inUse[ipv4ToUint32(ip)] = struct{}{}
 	}
 
-	_, err = state.allocate(true, rangeConfig)
+	_, err = nextAvailableIP(true, inUse, rangeConfig)
 	if !errors.Is(err, errNoControlPlaneIPsAvailable) {
 		t.Fatalf("expected errNoControlPlaneIPsAvailable, got %v", err)
 	}

--- a/controllers/dockyardsnodepool_controller.go
+++ b/controllers/dockyardsnodepool_controller.go
@@ -73,7 +73,9 @@ type DockyardsNodePoolReconciler struct {
 	DockyardsConfig                      *dyconfig.ConfigManager
 }
 
-const clusterDataVolumeStorageClassNameKey = "dataVolumeStorageClassName"
+const (
+	clusterDataVolumeStorageClassNameKey = "dataVolumeStorageClassName"
+)
 
 func (r *DockyardsNodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, reterr error) {
 	logger := ctrl.LoggerFrom(ctx)
@@ -535,6 +537,15 @@ func (r *DockyardsNodePoolReconciler) labelConfigPatch(labels map[string]string)
 	}
 }
 
+func (r *DockyardsNodePoolReconciler) taintConfigPatch(taints map[string]string) talospatchv1.Config {
+	return talospatchv1.Config{
+		Version: talospatchv1.ConfigVersion,
+		Machine: talospatchv1.MachineConfig{
+			NodeTaints: taints,
+		},
+	}
+}
+
 func (r *DockyardsNodePoolReconciler) addNodePoolNodeLabelsConfigPatch(ctx context.Context, dockyardsNodePool *dockyardsv1.NodePool, strategicPatches *StrategicPatches) error {
 	unstructuredDockyardsNodePoolFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackend := unstructured.Unstructured{
 		Object: map[string]any{
@@ -565,6 +576,63 @@ func (r *DockyardsNodePoolReconciler) addNodePoolNodeLabelsConfigPatch(ctx conte
 	err = strategicPatches.Add(ptr.To(patch))
 	if err != nil {
 		return fmt.Errorf("could not add node labels strategic patch: %w", err)
+	}
+
+	return nil
+}
+
+func (r *DockyardsNodePoolReconciler) addNodePoolNodeTaintsConfigPatch(ctx context.Context, dockyardsNodePool *dockyardsv1.NodePool, strategicPatches *StrategicPatches) error {
+	unstructuredDockyardsNodePoolFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackend := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": dockyardsv1.GroupVersion.String(),
+			"kind":       dockyardsv1.NodePoolKind,
+			"metadata": map[string]any{
+				"name":      dockyardsNodePool.Name,
+				"namespace": dockyardsNodePool.Namespace,
+			},
+		},
+	}
+
+	err := r.Get(ctx, client.ObjectKeyFromObject(&unstructuredDockyardsNodePoolFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackend), &unstructuredDockyardsNodePoolFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackend)
+	if err != nil {
+		return fmt.Errorf("could not get unstructured nodepool object: %w", err)
+	}
+
+	value := unstructuredDockyardsNodePoolFIXMERemoveThisWhenTalosHasUpdatedClusterAPIAndSoWeCanUpdateBackend.Object
+	taints, found, err := unstructured.NestedStringMap(value, "spec", "nodeTaints")
+	if err != nil {
+		return fmt.Errorf("could not read spec.nodeTaints: %w", err)
+	}
+	if !found || len(taints) == 0 {
+		return nil
+	}
+
+	for key, value := range taints {
+		value = strings.TrimSpace(value)
+
+		splitIndex := strings.LastIndex(value, ":")
+		if splitIndex == -1 {
+			return fmt.Errorf("spec.nodeTaints.%s must be formatted as <value>:<effect>", key)
+		}
+
+		effect := strings.TrimSpace(value[splitIndex+1:])
+		if effect == "" {
+			return fmt.Errorf("spec.nodeTaints.%s effect is required", key)
+		}
+
+		switch corev1.TaintEffect(effect) {
+		case corev1.TaintEffectNoSchedule, corev1.TaintEffectPreferNoSchedule, corev1.TaintEffectNoExecute:
+		default:
+			return fmt.Errorf("spec.nodeTaints.%s.effect %q is invalid", key, effect)
+		}
+
+		taints[key] = value
+	}
+
+	patch := r.taintConfigPatch(taints)
+	err = strategicPatches.Add(ptr.To(patch))
+	if err != nil {
+		return fmt.Errorf("could not add node taints strategic patch: %w", err)
 	}
 
 	return nil
@@ -636,6 +704,13 @@ func (r *DockyardsNodePoolReconciler) reconcileTalosControlPlane(ctx context.Con
 		conditions.MarkFalse(dockyardsNodePool, TalosControlPlaneReconciledCondition, ErrorReconcilingReason, "%s", err)
 
 		return ctrl.Result{}, nil
+	}
+
+	err = r.addNodePoolNodeTaintsConfigPatch(ctx, dockyardsNodePool, &strategicPatches)
+	if err != nil {
+		conditions.MarkFalse(dockyardsNodePool, TalosControlPlaneReconciledCondition, ErrorReconcilingReason, "%s", err)
+
+		return ctrl.Result{}, err
 	}
 
 	controlPlanePatch := talospatchv1.Config{
@@ -795,6 +870,11 @@ func (r *DockyardsNodePoolReconciler) reconcileTalosConfigTemplate(ctx context.C
 	}
 
 	err = r.addNodePoolNodeLabelsConfigPatch(ctx, dockyardsNodePool, &strategicPatches)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	err = r.addNodePoolNodeTaintsConfigPatch(ctx, dockyardsNodePool, &strategicPatches)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/controllers/dockyardsnodepool_controller.go
+++ b/controllers/dockyardsnodepool_controller.go
@@ -456,6 +456,10 @@ func (r *DockyardsNodePoolReconciler) talosConfigPatch(dockyardsCluster *dockyar
 
 func (r *DockyardsNodePoolReconciler) resolveDataVolumeStorageClassName(ctx context.Context, dockyardsNodePool *dockyardsv1.NodePool) (*string, error) {
 	ownerCluster, err := apiutil.GetOwnerCluster(ctx, r.Client, dockyardsNodePool)
+	if apierrors.IsNotFound(err) {
+		return r.DataVolumeStorageClassName, nil
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/dockyardsnodepool_controller.go
+++ b/controllers/dockyardsnodepool_controller.go
@@ -73,6 +73,8 @@ type DockyardsNodePoolReconciler struct {
 	DockyardsConfig                      *dyconfig.ConfigManager
 }
 
+const clusterDataVolumeStorageClassNameKey = "dataVolumeStorageClassName"
+
 func (r *DockyardsNodePoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, reterr error) {
 	logger := ctrl.LoggerFrom(ctx)
 
@@ -156,6 +158,11 @@ func (r *DockyardsNodePoolReconciler) reconcileMachineTemplate(ctx context.Conte
 		return ctrl.Result{}, err
 	}
 
+	storageClassName, err := r.resolveDataVolumeStorageClassName(ctx, dockyardsNodePool)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	machineTemplate := providerv1.KubevirtMachineTemplate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dockyardsNodePool.Name,
@@ -184,8 +191,6 @@ func (r *DockyardsNodePoolReconciler) reconcileMachineTemplate(ctx context.Conte
 		cpu := dockyardsNodePool.Spec.Resources.Cpu()
 		storage := dockyardsNodePool.Spec.Resources.Storage()
 		memory := dockyardsNodePool.Spec.Resources.Memory()
-
-		storageClassName := r.DataVolumeStorageClassName
 
 		dataVolumeTemplates := []kubevirtv1.DataVolumeTemplateSpec{
 			{
@@ -445,6 +450,45 @@ func (r *DockyardsNodePoolReconciler) talosConfigPatch(dockyardsCluster *dockyar
 	}
 
 	return patch
+}
+
+func (r *DockyardsNodePoolReconciler) resolveDataVolumeStorageClassName(ctx context.Context, dockyardsNodePool *dockyardsv1.NodePool) (*string, error) {
+	ownerCluster, err := apiutil.GetOwnerCluster(ctx, r.Client, dockyardsNodePool)
+	if err != nil {
+		return nil, err
+	}
+
+	if ownerCluster == nil {
+		return r.DataVolumeStorageClassName, nil
+	}
+
+	unstructuredDockyardsCluster := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": dockyardsv1.GroupVersion.String(),
+			"kind":       dockyardsv1.ClusterKind,
+			"metadata": map[string]any{
+				"name":      ownerCluster.Name,
+				"namespace": ownerCluster.Namespace,
+			},
+		},
+	}
+
+	err = r.Get(ctx, client.ObjectKeyFromObject(&unstructuredDockyardsCluster), &unstructuredDockyardsCluster)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterStorageClassName, found, err := unstructured.NestedString(unstructuredDockyardsCluster.Object, "spec", "advanced", "kubevirt", clusterDataVolumeStorageClassNameKey)
+	if err != nil {
+		return nil, err
+	}
+
+	clusterStorageClassName = strings.TrimSpace(clusterStorageClassName)
+	if found && clusterStorageClassName != "" {
+		return ptr.To(clusterStorageClassName), nil
+	}
+
+	return r.DataVolumeStorageClassName, nil
 }
 
 func (r *DockyardsNodePoolReconciler) timeSyncConfigPatch() talospatchv1.TimeSyncConfig {

--- a/controllers/dockyardsnodepool_controller_test.go
+++ b/controllers/dockyardsnodepool_controller_test.go
@@ -185,6 +185,70 @@ func TestDockyardsNodePoolReconciler_ReconcileMachineTemplate(t *testing.T) {
 		}
 	}
 
+	newOwnedNodePool := func(t *testing.T, owner dockyardsv1.Cluster) dockyardsv1.NodePool {
+		t.Helper()
+
+		nodePool := dockyardsv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-owned-",
+				Namespace:    owner.Namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: dockyardsv1.GroupVersion.String(),
+						Kind:       dockyardsv1.ClusterKind,
+						Name:       owner.Name,
+						UID:        owner.UID,
+					},
+				},
+			},
+			Spec: dockyardsv1.NodePoolSpec{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU:     resource.MustParse("2"),
+					corev1.ResourceMemory:  resource.MustParse("2Gi"),
+					corev1.ResourceStorage: resource.MustParse("8G"),
+				},
+			},
+		}
+
+		err := c.Create(ctx, &nodePool)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return nodePool
+	}
+
+	setClusterStorageClassOverride := func(t *testing.T, owner dockyardsv1.Cluster, value string) {
+		t.Helper()
+
+		u := unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": dockyardsv1.GroupVersion.String(),
+				"kind":       dockyardsv1.ClusterKind,
+				"metadata": map[string]any{
+					"name":      owner.Name,
+					"namespace": owner.Namespace,
+				},
+			},
+		}
+
+		err := c.Get(ctx, client.ObjectKeyFromObject(&u), &u)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		patch := client.MergeFrom(u.DeepCopy())
+		err = unstructured.SetNestedField(u.Object, value, "spec", "advanced", "kubevirt", clusterDataVolumeStorageClassNameKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = c.Patch(ctx, &u, patch)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	t.Run("test machine template resources", func(t *testing.T) {
 		nodePool := dockyardsv1.NodePool{
 			ObjectMeta: metav1.ObjectMeta{
@@ -377,6 +441,132 @@ func TestDockyardsNodePoolReconciler_ReconcileMachineTemplate(t *testing.T) {
 				t.Fatalf("expected data volume template %q to have pvc", dvt.Name)
 			}
 			assertNonBlockVolumeMode(t, dvt.Spec.PVC.VolumeMode)
+		}
+	})
+
+	t.Run("test machine template resources with cluster storage class override", func(t *testing.T) {
+		overriddenStorageClassName := "cluster-fast"
+
+		owner := dockyardsv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "owner-",
+				Namespace:    namespace.Name,
+			},
+		}
+		err := c.Create(ctx, &owner)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		setClusterStorageClassOverride(t, owner, overriddenStorageClassName)
+
+		nodePool := newOwnedNodePool(t, owner)
+
+		_, err = reconciler.reconcileMachineTemplate(ctx, &nodePool)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var actual providerv1.KubevirtMachineTemplate
+		err = c.Get(ctx, client.ObjectKeyFromObject(&nodePool), &actual)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, dvt := range actual.Spec.Template.Spec.VirtualMachineTemplate.Spec.DataVolumeTemplates {
+			if dvt.Spec.PVC == nil {
+				t.Fatalf("expected data volume template %q to have pvc", dvt.Name)
+			}
+
+			if dvt.Spec.PVC.StorageClassName == nil {
+				t.Fatalf("expected data volume template %q to have storage class", dvt.Name)
+			}
+
+			if *dvt.Spec.PVC.StorageClassName != overriddenStorageClassName {
+				t.Fatalf("expected storage class %q, got %q", overriddenStorageClassName, *dvt.Spec.PVC.StorageClassName)
+			}
+		}
+	})
+
+	t.Run("test machine template resources fallback storage class without override", func(t *testing.T) {
+		owner := dockyardsv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "owner-",
+				Namespace:    namespace.Name,
+			},
+		}
+		err := c.Create(ctx, &owner)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		nodePool := newOwnedNodePool(t, owner)
+
+		_, err = reconciler.reconcileMachineTemplate(ctx, &nodePool)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var actual providerv1.KubevirtMachineTemplate
+		err = c.Get(ctx, client.ObjectKeyFromObject(&nodePool), &actual)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, dvt := range actual.Spec.Template.Spec.VirtualMachineTemplate.Spec.DataVolumeTemplates {
+			if dvt.Spec.PVC == nil {
+				t.Fatalf("expected data volume template %q to have pvc", dvt.Name)
+			}
+
+			if dvt.Spec.PVC.StorageClassName == nil {
+				t.Fatalf("expected data volume template %q to have storage class", dvt.Name)
+			}
+
+			if *dvt.Spec.PVC.StorageClassName != dataVolumeStorageClassName {
+				t.Fatalf("expected storage class %q, got %q", dataVolumeStorageClassName, *dvt.Spec.PVC.StorageClassName)
+			}
+		}
+	})
+
+	t.Run("test machine template resources fallback storage class with empty override", func(t *testing.T) {
+		owner := dockyardsv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "owner-",
+				Namespace:    namespace.Name,
+			},
+		}
+		err := c.Create(ctx, &owner)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		setClusterStorageClassOverride(t, owner, "")
+
+		nodePool := newOwnedNodePool(t, owner)
+
+		_, err = reconciler.reconcileMachineTemplate(ctx, &nodePool)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var actual providerv1.KubevirtMachineTemplate
+		err = c.Get(ctx, client.ObjectKeyFromObject(&nodePool), &actual)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for _, dvt := range actual.Spec.Template.Spec.VirtualMachineTemplate.Spec.DataVolumeTemplates {
+			if dvt.Spec.PVC == nil {
+				t.Fatalf("expected data volume template %q to have pvc", dvt.Name)
+			}
+
+			if dvt.Spec.PVC.StorageClassName == nil {
+				t.Fatalf("expected data volume template %q to have storage class", dvt.Name)
+			}
+
+			if *dvt.Spec.PVC.StorageClassName != dataVolumeStorageClassName {
+				t.Fatalf("expected storage class %q, got %q", dataVolumeStorageClassName, *dvt.Spec.PVC.StorageClassName)
+			}
 		}
 	})
 

--- a/controllers/dockyardsnodepool_controller_test.go
+++ b/controllers/dockyardsnodepool_controller_test.go
@@ -1013,6 +1013,283 @@ func TestDockyardsNodePoolReconciler_ReconcileTalosControlPlane(t *testing.T) {
 		}
 	})
 
+	t.Run("test controlplane node taints", func(t *testing.T) {
+		owner := dockyardsv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+				Namespace:    namespace.Name,
+			},
+		}
+
+		err := c.Create(ctx, &owner)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		patch := client.MergeFrom(owner.DeepCopy())
+		owner.Status.APIEndpoint = dockyardsv1.ClusterAPIEndpoint{
+			Host: "localhost",
+			Port: 6443,
+		}
+		err = c.Status().Patch(ctx, &owner, patch)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cluster := clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      owner.Name,
+				Namespace: owner.Namespace,
+			},
+		}
+		err = c.Create(ctx, &cluster)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		nodePool := dockyardsv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: owner.Name + "-test-",
+				Namespace:    owner.Namespace,
+			},
+		}
+		err = c.Create(ctx, &nodePool)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// The NodePool type doesn't currently model spec.nodeTaints, so patch it in unstructured.
+		var u unstructured.Unstructured
+		u.SetAPIVersion(dockyardsv1.GroupVersion.String())
+		u.SetKind(dockyardsv1.NodePoolKind)
+		u.SetName(nodePool.Name)
+		u.SetNamespace(nodePool.Namespace)
+		err = c.Get(ctx, client.ObjectKeyFromObject(&u), &u)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		p := client.MergeFrom(u.DeepCopy())
+		err = unstructured.SetNestedStringMap(u.Object, map[string]string{
+			"node-role.kubernetes.io/control-plane": "hz:NoSchedule",
+		}, "spec", "nodeTaints")
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = c.Patch(ctx, &u, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = reconciler.reconcileTalosControlPlane(ctx, &nodePool, &owner)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var actual controlplanev1.TalosControlPlane
+		err = c.Get(ctx, client.ObjectKeyFromObject(&nodePool), &actual)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		taintsPatch, err := yaml.Marshal(talospatchv1.Config{
+			Version: talospatchv1.ConfigVersion,
+			Machine: talospatchv1.MachineConfig{
+				NodeTaints: map[string]string{"node-role.kubernetes.io/control-plane": "hz:NoSchedule"},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		configPatch, err := yaml.Marshal(talospatchv1.Config{
+			Version: talospatchv1.ConfigVersion,
+			Cluster: talospatchv1.ClusterConfig{
+				APIServer: talospatchv1.APIServerConfig{
+					CertSANs: []string{owner.Status.APIEndpoint.Host},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := controlplanev1.TalosControlPlane{
+			ObjectMeta: actual.ObjectMeta,
+			Spec: controlplanev1.TalosControlPlaneSpec{
+				ControlPlaneConfig: controlplanev1.ControlPlaneConfig{
+					ControlPlaneConfig: bootstrapv1.TalosConfigSpec{
+						GenerateType:     "controlplane",
+						TalosVersion:     "v1.12",
+						StrategicPatches: []string{string(taintsPatch), string(configPatch)},
+					},
+				},
+				InfrastructureTemplate: corev1.ObjectReference{
+					APIVersion: providerv1.GroupVersion.String(),
+					Kind:       "KubevirtMachineTemplate",
+					Name:       nodePool.Name,
+					Namespace:  nodePool.Namespace,
+				},
+			},
+		}
+
+		if !cmp.Equal(actual, expected) {
+			t.Errorf("diff: %s", cmp.Diff(expected, actual))
+			showYamlExpectedAndActual(t, expected.Spec, actual.Spec)
+		}
+	})
+
+	t.Run("test controlplane node taints with invalid effect returns error", func(t *testing.T) {
+		owner := dockyardsv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+				Namespace:    namespace.Name,
+			},
+		}
+
+		err := c.Create(ctx, &owner)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		patch := client.MergeFrom(owner.DeepCopy())
+		owner.Status.APIEndpoint = dockyardsv1.ClusterAPIEndpoint{
+			Host: "localhost",
+			Port: 6443,
+		}
+		err = c.Status().Patch(ctx, &owner, patch)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cluster := clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      owner.Name,
+				Namespace: owner.Namespace,
+			},
+		}
+		err = c.Create(ctx, &cluster)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		nodePool := dockyardsv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: owner.Name + "-test-",
+				Namespace:    owner.Namespace,
+			},
+		}
+		err = c.Create(ctx, &nodePool)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// The NodePool type doesn't currently model spec.nodeTaints, so patch it in unstructured.
+		var u unstructured.Unstructured
+		u.SetAPIVersion(dockyardsv1.GroupVersion.String())
+		u.SetKind(dockyardsv1.NodePoolKind)
+		u.SetName(nodePool.Name)
+		u.SetNamespace(nodePool.Namespace)
+		err = c.Get(ctx, client.ObjectKeyFromObject(&u), &u)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		p := client.MergeFrom(u.DeepCopy())
+		err = unstructured.SetNestedStringMap(u.Object, map[string]string{
+			"node-role.kubernetes.io/control-plane": "hz:NeverSchedule",
+		}, "spec", "nodeTaints")
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = c.Patch(ctx, &u, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = reconciler.reconcileTalosControlPlane(ctx, &nodePool, &owner)
+		if err == nil {
+			t.Fatal("expected reconcileTalosControlPlane to return an error")
+		}
+	})
+
+	t.Run("test controlplane node taints with invalid object format returns error", func(t *testing.T) {
+		owner := dockyardsv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+				Namespace:    namespace.Name,
+			},
+		}
+
+		err := c.Create(ctx, &owner)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		patch := client.MergeFrom(owner.DeepCopy())
+		owner.Status.APIEndpoint = dockyardsv1.ClusterAPIEndpoint{
+			Host: "localhost",
+			Port: 6443,
+		}
+		err = c.Status().Patch(ctx, &owner, patch)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cluster := clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      owner.Name,
+				Namespace: owner.Namespace,
+			},
+		}
+		err = c.Create(ctx, &cluster)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		nodePool := dockyardsv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: owner.Name + "-test-",
+				Namespace:    owner.Namespace,
+			},
+		}
+		err = c.Create(ctx, &nodePool)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// The NodePool type doesn't currently model spec.nodeTaints, so patch it in unstructured.
+		var u unstructured.Unstructured
+		u.SetAPIVersion(dockyardsv1.GroupVersion.String())
+		u.SetKind(dockyardsv1.NodePoolKind)
+		u.SetName(nodePool.Name)
+		u.SetNamespace(nodePool.Namespace)
+		err = c.Get(ctx, client.ObjectKeyFromObject(&u), &u)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		p := client.MergeFrom(u.DeepCopy())
+		err = unstructured.SetNestedField(u.Object, map[string]any{
+			"node-role.kubernetes.io/control-plane": map[string]any{
+				"value":  "hz",
+				"effect": "NoSchedule",
+			},
+		}, "spec", "nodeTaints")
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = c.Patch(ctx, &u, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = reconciler.reconcileTalosControlPlane(ctx, &nodePool, &owner)
+		if err == nil {
+			t.Fatal("expected reconcileTalosControlPlane to return an error")
+		}
+	})
+
 	t.Run("test controlplane network plugin", func(t *testing.T) {
 		owner := dockyardsv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1937,6 +2214,146 @@ func TestDockyardsNodePoolReconciler_ReconcileTalosConfigTemplate(t *testing.T) 
 		if !cmp.Equal(actual, expected) {
 			t.Errorf("diff: %s", cmp.Diff(expected, actual))
 			showYamlExpectedAndActual(t, expected.Spec, actual.Spec)
+		}
+	})
+
+	t.Run("test config template node taints", func(t *testing.T) {
+		owner := dockyardsv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test",
+				Namespace:    namespace.Name,
+			},
+		}
+
+		err := c.Create(ctx, &owner)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		nodePool := dockyardsv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: owner.Name + "-test-",
+				Namespace:    owner.Namespace,
+			},
+		}
+
+		err = c.Create(ctx, &nodePool)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// The NodePool type doesn't currently model spec.nodeTaints, so patch it in unstructured.
+		var u unstructured.Unstructured
+		u.SetAPIVersion(dockyardsv1.GroupVersion.String())
+		u.SetKind(dockyardsv1.NodePoolKind)
+		u.SetName(nodePool.Name)
+		u.SetNamespace(nodePool.Namespace)
+		err = c.Get(ctx, client.ObjectKeyFromObject(&u), &u)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p := client.MergeFrom(u.DeepCopy())
+		err = unstructured.SetNestedStringMap(u.Object, map[string]string{
+			"node-role.kubernetes.io/worker": "hz:NoSchedule",
+		}, "spec", "nodeTaints")
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = c.Patch(ctx, &u, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = reconciler.reconcileTalosConfigTemplate(ctx, &nodePool, &owner)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var actual bootstrapv1.TalosConfigTemplate
+		err = c.Get(ctx, client.ObjectKeyFromObject(&nodePool), &actual)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		taintsPatch, err := yaml.Marshal(talospatchv1.Config{
+			Version: talospatchv1.ConfigVersion,
+			Machine: talospatchv1.MachineConfig{
+				NodeTaints: map[string]string{"node-role.kubernetes.io/worker": "hz:NoSchedule"},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := bootstrapv1.TalosConfigTemplate{
+			ObjectMeta: actual.ObjectMeta,
+			Spec: bootstrapv1.TalosConfigTemplateSpec{
+				Template: bootstrapv1.TalosConfigTemplateResource{
+					Spec: bootstrapv1.TalosConfigSpec{
+						GenerateType:     "worker",
+						TalosVersion:     "v1.12",
+						StrategicPatches: []string{string(taintsPatch)},
+					},
+				},
+			},
+		}
+
+		if !cmp.Equal(actual, expected) {
+			t.Errorf("diff: %s", cmp.Diff(expected, actual))
+			showYamlExpectedAndActual(t, expected.Spec, actual.Spec)
+		}
+	})
+
+	t.Run("test config template node taints with invalid effect returns error", func(t *testing.T) {
+		owner := dockyardsv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test",
+				Namespace:    namespace.Name,
+			},
+		}
+
+		err := c.Create(ctx, &owner)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		nodePool := dockyardsv1.NodePool{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: owner.Name + "-test-",
+				Namespace:    owner.Namespace,
+			},
+		}
+
+		err = c.Create(ctx, &nodePool)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// The NodePool type doesn't currently model spec.nodeTaints, so patch it in unstructured.
+		var u unstructured.Unstructured
+		u.SetAPIVersion(dockyardsv1.GroupVersion.String())
+		u.SetKind(dockyardsv1.NodePoolKind)
+		u.SetName(nodePool.Name)
+		u.SetNamespace(nodePool.Namespace)
+		err = c.Get(ctx, client.ObjectKeyFromObject(&u), &u)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p := client.MergeFrom(u.DeepCopy())
+		err = unstructured.SetNestedStringMap(u.Object, map[string]string{
+			"node-role.kubernetes.io/worker": "hz:NeverSchedule",
+		}, "spec", "nodeTaints")
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = c.Patch(ctx, &u, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = reconciler.reconcileTalosConfigTemplate(ctx, &nodePool, &owner)
+		if err == nil {
+			t.Fatal("expected reconcileTalosConfigTemplate to return an error")
 		}
 	})
 

--- a/controllers/dockyardsworkload_controller.go
+++ b/controllers/dockyardsworkload_controller.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -55,6 +56,11 @@ type DockyardsWorkloadReconciler struct {
 	GatewayParentReference gatewayapiv1.ParentReference
 	ClusterCache           clustercache.ClusterCache
 }
+
+const (
+	clusterGatewayParentRefNameKey      = "name"
+	clusterGatewayParentRefNamespaceKey = "namespace"
+)
 
 func (r *DockyardsWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)
@@ -101,12 +107,17 @@ func (r *DockyardsWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	objectKey := client.ObjectKey{
-		Name: string(r.GatewayParentReference.Name),
+	gatewayParentRef, err := r.resolveGatewayParentReference(ctx, ownerCluster)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
-	if r.GatewayParentReference.Namespace != nil {
-		objectKey.Namespace = string(*r.GatewayParentReference.Namespace)
+	objectKey := client.ObjectKey{
+		Name: string(gatewayParentRef.Name),
+	}
+
+	if gatewayParentRef.Namespace != nil {
+		objectKey.Namespace = string(*gatewayParentRef.Namespace)
 	}
 
 	var gateway gatewayapiv1.Gateway
@@ -288,7 +299,7 @@ func (r *DockyardsWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			}
 
 			httpRoute.Spec.ParentRefs = []gatewayapiv1.ParentReference{
-				r.GatewayParentReference,
+				gatewayParentRef,
 			}
 
 			return nil
@@ -318,7 +329,7 @@ func (r *DockyardsWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 			tlsRoute.Spec.CommonRouteSpec = gatewayapiv1.CommonRouteSpec{
 				ParentRefs: []gatewayapiv1.ParentReference{
-					r.GatewayParentReference,
+					gatewayParentRef,
 				},
 			}
 
@@ -390,6 +401,62 @@ func (r *DockyardsWorkloadReconciler) serviceToWorkload(ctx context.Context, obj
 			},
 		},
 	}
+}
+
+func (r *DockyardsWorkloadReconciler) resolveGatewayParentReference(ctx context.Context, ownerCluster *dockyardsv1.Cluster) (gatewayapiv1.ParentReference, error) {
+	unstructuredDockyardsCluster := unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": dockyardsv1.GroupVersion.String(),
+			"kind":       dockyardsv1.ClusterKind,
+			"metadata": map[string]any{
+				"name":      ownerCluster.Name,
+				"namespace": ownerCluster.Namespace,
+			},
+		},
+	}
+
+	err := r.Get(ctx, client.ObjectKeyFromObject(&unstructuredDockyardsCluster), &unstructuredDockyardsCluster)
+	if err != nil {
+		return gatewayapiv1.ParentReference{}, err
+	}
+
+	clusterParentRef, found, err := clusterGatewayParentReference(unstructuredDockyardsCluster.Object)
+	if err != nil {
+		return gatewayapiv1.ParentReference{}, err
+	}
+
+	if found {
+		return clusterParentRef, nil
+	}
+
+	return r.GatewayParentReference, nil
+}
+
+func clusterGatewayParentReference(cluster map[string]any) (gatewayapiv1.ParentReference, bool, error) {
+	name, found, err := unstructured.NestedString(cluster, "spec", "advanced", "gateway", "parentRef", clusterGatewayParentRefNameKey)
+	if err != nil {
+		return gatewayapiv1.ParentReference{}, false, err
+	}
+
+	name = strings.TrimSpace(name)
+	if !found || name == "" {
+		return gatewayapiv1.ParentReference{}, false, nil
+	}
+
+	namespace, found, err := unstructured.NestedString(cluster, "spec", "advanced", "gateway", "parentRef", clusterGatewayParentRefNamespaceKey)
+	if err != nil {
+		return gatewayapiv1.ParentReference{}, false, err
+	}
+
+	namespace = strings.TrimSpace(namespace)
+	if !found || namespace == "" {
+		return gatewayapiv1.ParentReference{}, false, nil
+	}
+
+	return gatewayapiv1.ParentReference{
+		Name:      gatewayapiv1.ObjectName(name),
+		Namespace: ptr.To(gatewayapiv1.Namespace(namespace)),
+	}, true, nil
 }
 
 func (r *DockyardsWorkloadReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/controllers/dockyardsworkload_controller_test.go
+++ b/controllers/dockyardsworkload_controller_test.go
@@ -1,0 +1,129 @@
+// Copyright 2025 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"testing"
+
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestClusterGatewayParentReference(t *testing.T) {
+	t.Run("returns parent ref when name and namespace are set", func(t *testing.T) {
+		cluster := map[string]any{
+			"spec": map[string]any{
+				"advanced": map[string]any{
+					"gateway": map[string]any{
+						"parentRef": map[string]any{
+							"name":      "shared-gateway",
+							"namespace": "gateway-system",
+						},
+					},
+				},
+			},
+		}
+
+		parentRef, found, err := clusterGatewayParentReference(cluster)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !found {
+			t.Fatal("expected to find gateway parent ref override")
+		}
+
+		if parentRef.Name != gatewayapiv1.ObjectName("shared-gateway") {
+			t.Fatalf("expected parent ref name %q, got %q", "shared-gateway", parentRef.Name)
+		}
+
+		if parentRef.Namespace == nil {
+			t.Fatal("expected parent ref namespace to be set")
+		}
+
+		if *parentRef.Namespace != gatewayapiv1.Namespace("gateway-system") {
+			t.Fatalf("expected parent ref namespace %q, got %q", "gateway-system", *parentRef.Namespace)
+		}
+	})
+
+	t.Run("returns not found when name is missing", func(t *testing.T) {
+		cluster := map[string]any{
+			"spec": map[string]any{
+				"advanced": map[string]any{
+					"gateway": map[string]any{
+						"parentRef": map[string]any{
+							"namespace": "gateway-system",
+						},
+					},
+				},
+			},
+		}
+
+		_, found, err := clusterGatewayParentReference(cluster)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if found {
+			t.Fatal("expected no gateway parent ref override")
+		}
+	})
+
+	t.Run("returns not found when namespace is missing", func(t *testing.T) {
+		cluster := map[string]any{
+			"spec": map[string]any{
+				"advanced": map[string]any{
+					"gateway": map[string]any{
+						"parentRef": map[string]any{
+							"name": "shared-gateway",
+						},
+					},
+				},
+			},
+		}
+
+		_, found, err := clusterGatewayParentReference(cluster)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if found {
+			t.Fatal("expected no gateway parent ref override")
+		}
+	})
+
+	t.Run("returns not found for empty values", func(t *testing.T) {
+		cluster := map[string]any{
+			"spec": map[string]any{
+				"advanced": map[string]any{
+					"gateway": map[string]any{
+						"parentRef": map[string]any{
+							"name":      "   ",
+							"namespace": "  ",
+						},
+					},
+				},
+			},
+		}
+
+		_, found, err := clusterGatewayParentReference(cluster)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if found {
+			t.Fatal("expected no gateway parent ref override")
+		}
+	})
+}

--- a/internal/talospatch/v1alpha1/types.go
+++ b/internal/talospatch/v1alpha1/types.go
@@ -48,6 +48,7 @@ type MachineConfig struct {
 	Env        Env               `yaml:"env,omitempty"`
 	Files      []MachineFile     `yaml:"files,omitempty"`
 	NodeLabels map[string]string `yaml:"nodeLabels,omitempty"`
+	NodeTaints map[string]string `yaml:"nodeTaints,omitempty"`
 }
 
 var _ yaml.IsZeroer = &MachineConfig{}
@@ -63,6 +64,9 @@ func (c *MachineConfig) IsZero() bool {
 		return false
 	}
 	if c.NodeLabels != nil {
+		return false
+	}
+	if c.NodeTaints != nil {
 		return false
 	}
 	return true


### PR DESCRIPTION
- **Allow per-cluster root disk storage class override**
- **Add per-cluster workload gateway parentRef override**
- **Use Talos-native NodePool taints format**
- **Add new CRD to handle IPs for wl clusters**
- **nitpick: update ipamclaim CRD name**
- **ipamclaim add printer columns**
